### PR TITLE
BTS-49: Deploy price history API to AWS Lambda.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -47,6 +47,12 @@ Resources:
             ApiId: !Ref AppHttpApi
             Path: /api/Compare
             Method: GET
+        PriceHistoryGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref AppHttpApi
+            Path: /api/Scraping/priceHistory
+            Method: GET
       Environment:
         Variables:
           ConnectionStrings__DefaultConnection: !Ref DbConnectionString


### PR DESCRIPTION
Related Jira Key: BTS-49