### PR TITLE
BTS-90: Added Woolworths lower-shelf DOM scraper with paging + filters

### DIFF
--- a/src/PriceCompareCore/Interfaces/IWoolworthsLowerShelfDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IWoolworthsLowerShelfDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities.Scraping;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IWoolworthsLowerShelfDomScraperService
+    {
+        Task<List<WoolworthsSpecialProduct>> ScrapeAsync(int limit = 20, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Services/WoolworthsLowerShelfDomScraperService.cs
+++ b/src/PriceCompareCore/Services/WoolworthsLowerShelfDomScraperService.cs
@@ -1,0 +1,476 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+using PriceCompareCore.Interfaces;
+using PriceCompareData.Entities.Scraping;
+
+namespace PriceCompareCore.Services
+{
+    public class WoolworthsLowerShelfDomScraperService : IWoolworthsLowerShelfDomScraperService
+    {
+        private const string LowerShelfUrl = "https://www.woolworths.com.au/shop/browse/specials/lower-shelf-price";
+        private const string DefaultUa =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+
+        private readonly ILogger<WoolworthsLowerShelfDomScraperService> _logger;
+
+        public WoolworthsLowerShelfDomScraperService(ILogger<WoolworthsLowerShelfDomScraperService> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<List<WoolworthsSpecialProduct>> ScrapeAsync(int limit = 20, CancellationToken ct = default)
+        {
+            var hardCap = GetDomHardCap();
+            if (limit <= 0) limit = hardCap;
+            if (limit > hardCap) limit = hardCap;
+
+            using var pw = await Playwright.CreateAsync();
+            await using var browser = await pw.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = GetHeadless(),
+                SlowMo = GetSlowMoMs(),
+                Channel = GetChromeChannel(),
+                Args = new[]
+                {
+                    "--disable-dev-shm-usage",
+                    "--no-sandbox",
+                    "--disable-gpu",
+                    "--disable-features=IsolateOrigins,site-per-process",
+                    "--disable-blink-features=AutomationControlled"
+                }
+            });
+
+            await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+            {
+                Locale = "en-AU",
+                UserAgent = GetUserAgent(),
+                TimezoneId = "Australia/Sydney",
+                ViewportSize = new ViewportSize { Width = 1365, Height = 768 },
+                ScreenSize = new ScreenSize { Width = 1365, Height = 768 },
+                DeviceScaleFactor = 1,
+                IsMobile = false,
+                HasTouch = false,
+                ExtraHTTPHeaders = new Dictionary<string, string>
+                {
+                    ["Accept-Language"] = "en-AU,en;q=0.9",
+                    ["DNT"] = "1"
+                }
+            });
+
+            await context.AddInitScriptAsync(GetStealthScript());
+
+            var page = await context.NewPageAsync();
+            var domItems = new List<DomProduct>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var maxPages = GetMaxPages();
+            var startPage = GetStartPage();
+
+            for (var pageNumber = startPage; pageNumber <= maxPages && domItems.Count < limit; pageNumber++)
+            {
+                var url = BuildLowerShelfUrl(pageNumber);
+                _logger.LogInformation("WWS DOM: goto lower shelf page {Page}...", pageNumber);
+                await page.GotoAsync(url, new PageGotoOptions
+                {
+                    WaitUntil = WaitUntilState.DOMContentLoaded,
+                    Timeout = 60000
+                });
+
+                await HumanDelayAsync(page, 1200, 2200);
+                if (pageNumber == startPage)
+                {
+                    await TryClickAsync(page, "button:has-text(\"Accept\")", 1500);
+                }
+                await HumanDelayAsync(page, 800, 1400);
+                await page.Mouse.MoveAsync(250, 250);
+
+                var selector = await WaitForAnySelectorAsync(
+                    page,
+                    new[]
+                    {
+                        "a[href*='/shop/productdetails/']",
+                        "[data-testid*='product-tile']",
+                        "[data-testid*='product']"
+                    },
+                    20000);
+
+                if (selector is null)
+                {
+                    _logger.LogWarning("WWS DOM: no product selector detected on page {Page}.", pageNumber);
+                    break;
+                }
+
+                var remaining = limit - domItems.Count;
+                var pageItems = await ExtractDomItemsAsync(page, remaining, ct, seen, GetMaxScrollRounds());
+                _logger.LogInformation("WWS DOM: page {Page} -> {Count} items.", pageNumber, pageItems.Count);
+
+                if (pageItems.Count == 0)
+                {
+                    break;
+                }
+
+                domItems.AddRange(pageItems);
+            }
+
+            var mapped = MapDomItems(domItems);
+            _logger.LogInformation("WWS DOM: extracted {Count} products.", mapped.Count);
+
+            return mapped;
+        }
+
+        private static List<WoolworthsSpecialProduct> MapDomItems(IReadOnlyList<DomProduct> items)
+        {
+            var result = new List<WoolworthsSpecialProduct>();
+            foreach (var item in items)
+            {
+                var name = item.Name?.Trim() ?? string.Empty;
+                if (!IsValidName(name))
+                {
+                    continue;
+                }
+
+                var price = ParseMoney(ExtractFromAria(item.Aria, "Non-member price"));
+                var was = ParseMoney(ExtractFromAria(item.Aria, "Was"));
+                if (!price.HasValue)
+                {
+                    continue;
+                }
+                var savings = (was.HasValue && price.HasValue && was.Value > price.Value)
+                    ? was.Value - price.Value
+                    : (decimal?)null;
+
+                result.Add(new WoolworthsSpecialProduct
+                {
+                    Stockcode = 0,
+                    Barcode = string.Empty,
+                    DisplayName = name,
+                    Brand = string.Empty,
+                    Price = price ?? 0m,
+                    WasPrice = was,
+                    SavingsAmount = savings,
+                    IsOnSpecial = true,
+                    CupPrice = null,
+                    CupString = null,
+                    LargeImageFile = item.Image,
+                    ScrapedAt = DateTime.UtcNow
+                });
+            }
+
+            return result;
+        }
+
+        private static decimal? ParseMoney(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return null;
+            }
+
+            var cleaned = raw.Replace("Was", "", StringComparison.OrdinalIgnoreCase)
+                .Replace("$", "", StringComparison.OrdinalIgnoreCase)
+                .Replace(" ", "");
+
+            return decimal.TryParse(cleaned, NumberStyles.Number, CultureInfo.InvariantCulture, out var value)
+                ? value
+                : null;
+        }
+
+        private static string? ExtractFromAria(string? aria, string key)
+        {
+            if (string.IsNullOrWhiteSpace(aria))
+            {
+                return null;
+            }
+
+            var marker = key + " ";
+            var idx = aria.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0)
+            {
+                return null;
+            }
+
+            var start = idx + marker.Length;
+            var end = aria.IndexOf(',', start);
+            if (end < 0)
+            {
+                end = aria.Length;
+            }
+
+            var segment = aria.Substring(start, end - start).Trim();
+            return segment.StartsWith("$", StringComparison.OrdinalIgnoreCase) ? segment : "$" + segment;
+        }
+
+        private static async Task<List<DomProduct>> ExtractDomItemsAsync(
+            IPage page,
+            int limit,
+            CancellationToken ct,
+            HashSet<string> seen,
+            int maxRounds)
+        {
+            var results = new List<DomProduct>();
+
+            var locator = page.Locator("a[href*='/shop/productdetails/'][aria-label]");
+            var stableRounds = 0;
+
+            while (results.Count < limit && stableRounds < 3 && maxRounds-- > 0)
+            {
+                var before = results.Count;
+                var total = await locator.CountAsync();
+
+                for (var i = 0; i < total && results.Count < limit; i++)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        return results;
+                    }
+
+                    var anchor = locator.Nth(i);
+                    var href = (await anchor.GetAttributeAsync("href")) ?? string.Empty;
+                    if (string.IsNullOrWhiteSpace(href))
+                    {
+                        continue;
+                    }
+
+                    var fullHref = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                        ? href
+                        : new Uri(new Uri(LowerShelfUrl), href).ToString();
+
+                    if (!seen.Add(fullHref))
+                    {
+                        continue;
+                    }
+
+                    var aria = (await anchor.GetAttributeAsync("aria-label")) ?? string.Empty;
+                    if (!IsProductAria(aria))
+                    {
+                        continue;
+                    }
+
+                    var name = ExtractNameFromAria(aria);
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        name = (await anchor.InnerTextAsync()).Trim();
+                    }
+
+                    string image = string.Empty;
+                    var img = anchor.Locator("img");
+                    if (await img.CountAsync() > 0)
+                    {
+                        image = (await img.First.GetAttributeAsync("src"))
+                                ?? (await img.First.GetAttributeAsync("data-src"))
+                                ?? string.Empty;
+                    }
+
+                    results.Add(new DomProduct
+                    {
+                        Name = name,
+                        Href = fullHref,
+                        Image = image,
+                        Aria = aria
+                    });
+                }
+
+                if (results.Count == before)
+                {
+                    stableRounds++;
+                }
+                else
+                {
+                    stableRounds = 0;
+                }
+
+                if (results.Count >= limit)
+                {
+                    break;
+                }
+
+                await page.EvaluateAsync("() => window.scrollBy(0, document.body.scrollHeight)");
+                await HumanDelayAsync(page, 700, 1200);
+            }
+
+            return results;
+        }
+
+        private static string GetUserAgent()
+        {
+            var ua = Environment.GetEnvironmentVariable("WWS_USER_AGENT");
+            return string.IsNullOrWhiteSpace(ua) ? DefaultUa : ua.Trim();
+        }
+
+        private static int GetSlowMoMs()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_SLOWMO_MS");
+            return int.TryParse(raw, out var ms) && ms >= 0 ? ms : 60;
+        }
+
+        private static bool GetHeadless()
+        {
+            var headful = Environment.GetEnvironmentVariable("WWS_HEADFUL");
+            return !string.Equals(headful, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string? GetChromeChannel()
+        {
+            var useChrome = Environment.GetEnvironmentVariable("WWS_USE_CHROME_CHANNEL");
+            return string.Equals(useChrome, "true", StringComparison.OrdinalIgnoreCase) ? "chrome" : null;
+        }
+
+        private static async Task<bool> TryClickAsync(IPage page, string selector, int timeoutMs)
+        {
+            try
+            {
+                await page.ClickAsync(selector, new PageClickOptions { Timeout = timeoutMs });
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static async Task HumanDelayAsync(IPage page, int minMs, int maxMs)
+        {
+            if (minMs < 0) minMs = 0;
+            if (maxMs < minMs) maxMs = minMs;
+            var delay = Random.Shared.Next(minMs, maxMs + 1);
+            await page.WaitForTimeoutAsync(delay);
+        }
+
+        private static async Task<string?> WaitForAnySelectorAsync(IPage page, IReadOnlyList<string> selectors, int timeoutMs)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                foreach (var selector in selectors)
+                {
+                    try
+                    {
+                        var count = await page.Locator(selector).CountAsync();
+                        if (count > 0)
+                        {
+                            return selector;
+                        }
+                    }
+                    catch
+                    {
+                        // ignore and keep polling
+                    }
+                }
+
+                await page.WaitForTimeoutAsync(500);
+            }
+
+            return null;
+        }
+
+        private static string GetStealthScript()
+        {
+            return @"
+Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+Object.defineProperty(navigator, 'languages', { get: () => ['en-AU', 'en'] });
+Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+window.chrome = window.chrome || { runtime: {} };
+const originalQuery = window.navigator.permissions.query;
+window.navigator.permissions.query = (parameters) => (
+  parameters.name === 'notifications'
+    ? Promise.resolve({ state: Notification.permission })
+    : originalQuery(parameters)
+);
+";
+        }
+
+        private static int GetDomHardCap()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_MAX_ITEMS");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 1000;
+        }
+
+        private static int GetMaxScrollRounds()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_MAX_ROUNDS");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 6;
+        }
+
+        private static int GetMaxPages()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_MAX_PAGES");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 50;
+        }
+
+        private static int GetStartPage()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_START_PAGE");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 1;
+        }
+
+        private static string BuildLowerShelfUrl(int pageNumber)
+            => $"{LowerShelfUrl}?pageNumber={pageNumber}";
+
+        private sealed class DomProduct
+        {
+            public string? Name { get; set; }
+            public string? Href { get; set; }
+            public string? Image { get; set; }
+            public string? Aria { get; set; }
+        }
+
+        private static bool IsProductAria(string? aria)
+        {
+            if (string.IsNullOrWhiteSpace(aria))
+            {
+                return false;
+            }
+
+            return aria.Contains("Non-member price", StringComparison.OrdinalIgnoreCase) ||
+                   aria.Contains("Find out more about", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ExtractNameFromAria(string? aria)
+        {
+            if (string.IsNullOrWhiteSpace(aria))
+            {
+                return string.Empty;
+            }
+
+            if (aria.Contains("Find out more about", StringComparison.OrdinalIgnoreCase))
+            {
+                var start = aria.IndexOf("Find out more about", StringComparison.OrdinalIgnoreCase);
+                if (start >= 0)
+                {
+                    var tail = aria.Substring(start + "Find out more about".Length).Trim();
+                    var comma = tail.IndexOf(',', StringComparison.Ordinal);
+                    return (comma > 0 ? tail[..comma] : tail).Trim();
+                }
+            }
+
+            var firstPeriod = aria.IndexOf('.', StringComparison.Ordinal);
+            return firstPeriod > 0 ? aria[..firstPeriod].Trim() : aria.Trim();
+        }
+
+        private static bool IsValidName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            if (string.Equals(name, "out of stock", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!name.Any(char.IsLetter))
+            {
+                return false;
+            }
+
+            return name.Length >= 3;
+        }
+    }
+}

--- a/src/PriceCompareCore/Services/WoolworthsSpecialScraperService.cs
+++ b/src/PriceCompareCore/Services/WoolworthsSpecialScraperService.cs
@@ -38,9 +38,9 @@ namespace PriceCompareCore.Services
         };
 
         private const string SpecialsUrl = "https://www.woolworths.com.au/shop/browse/specials";
-        private const string ChromeUa =
+        private const string DefaultUa =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
-            "(KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 
         // Woolworths specials API 
         private const string SpecialsApiUrl =
@@ -87,17 +87,24 @@ namespace PriceCompareCore.Services
 
         public async Task<List<WoolworthsSpecialProduct>> GetAllOnSpecialProductsAsync(WoolworthsSpecialProductRequest request)
         {
+            var probeOnly = GetProbeOnly();
+
             // 1. Redis
-            var cached = await _cache.GetStringAsync(CacheKey.WOOLWORTHS_ON_SPECIAL_PRODUCTS);
-            if (!string.IsNullOrEmpty(cached))
+            if (!probeOnly)
             {
-                _logger.LogInformation("Using cached Woolworths specials data.");
-                var list = JsonSerializer.Deserialize<List<WoolworthsSpecialProduct>>(cached, _jsonOptions) ?? new();
-                return request is null ? list : ApplyFilters(list, request);
+                var cached = await _cache.GetStringAsync(CacheKey.WOOLWORTHS_ON_SPECIAL_PRODUCTS);
+                if (!string.IsNullOrEmpty(cached))
+                {
+                    _logger.LogInformation("Using cached Woolworths specials data.");
+                    var list = JsonSerializer.Deserialize<List<WoolworthsSpecialProduct>>(cached, _jsonOptions) ?? new();
+                    return request is null ? list : ApplyFilters(list, request);
+                }
             }
 
             var allProducts = new List<WoolworthsSpecialProduct>();
             var scrapedAt = DateTime.UtcNow;
+            var apiUrl = BuildSpecialsApiUrl();
+            WwsProbeResult? probeResult = null;
 
             // 2. Get Api info by Playwright 
             await _retryPolicy.ExecuteAsync(async () =>
@@ -106,41 +113,133 @@ namespace PriceCompareCore.Services
 
                 await using var browser = await pw.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
                 {
-                    Headless = true,
-                    Args = new[] { "--disable-dev-shm-usage", "--no-sandbox" }
+                    Headless = GetHeadless(),
+                    SlowMo = GetSlowMoMs(),
+                    Channel = GetChromeChannel(),
+                    Args = new[]
+                    {
+                        "--disable-dev-shm-usage",
+                        "--no-sandbox",
+                        "--disable-gpu",
+                        "--disable-features=IsolateOrigins,site-per-process",
+                        "--disable-blink-features=AutomationControlled"
+                    }
                 });
 
                 await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
                 {
-                    Locale = "en-US",
-                    UserAgent = ChromeUa
+                    Locale = "en-AU",
+                    UserAgent = GetUserAgent(),
+                    TimezoneId = "Australia/Sydney",
+                    ViewportSize = new ViewportSize { Width = 1365, Height = 768 },
+                    ScreenSize = new ScreenSize { Width = 1365, Height = 768 },
+                    DeviceScaleFactor = 1,
+                    IsMobile = false,
+                    HasTouch = false,
+                    ExtraHTTPHeaders = new Dictionary<string, string>
+                    {
+                        ["Accept-Language"] = "en-AU,en;q=0.9",
+                        ["DNT"] = "1"
+                    }
                 });
 
+                await context.AddInitScriptAsync(GetStealthScript());
+
                 var page = await context.NewPageAsync();
+                var apiHits = new List<ApiHit>();
+                var apiLock = new object();
+                page.Response += (_, resp) =>
+                {
+                    if (resp.Url.Contains("/apis/ui/products/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        lock (apiLock)
+                        {
+                            apiHits.Add(new ApiHit(resp.Status, resp.Url));
+                        }
+                    }
+                };
 
                 _logger.LogInformation("Goto specials page...");
                 await page.GotoAsync(SpecialsUrl, new PageGotoOptions
                 {
                     WaitUntil = WaitUntilState.DOMContentLoaded,
-                    Timeout = 45000
+                    Timeout = 60000
                 });
 
-                // Provide some time for anti-bot scripts to set cookies
-                await page.WaitForTimeoutAsync(3000);
+                // Provide some time for anti-bot scripts to set cookies + simulate user
+                await HumanDelayAsync(page, 1200, 2200);
+                await TryClickAsync(page, "button:has-text(\"Accept\")", 1500);
+                await HumanDelayAsync(page, 800, 1400);
+                await page.Mouse.MoveAsync(250, 250);
+                await page.Mouse.WheelAsync(0, 1200);
+                await HumanDelayAsync(page, 600, 1200);
+                await page.Mouse.WheelAsync(0, 1200);
+                await HumanDelayAsync(page, 600, 1200);
 
-                // Send API request dirextly
-                _logger.LogInformation("Fetching API: {Url}", SpecialsApiUrl);
-                var resp = await page.APIRequest.GetAsync(SpecialsApiUrl);
-
-                _logger.LogWarning("WWS API status={Status}", resp.Status);
-                foreach (var header in resp.Headers)
+                if (probeOnly)
                 {
-                    _logger.LogWarning("Header {Key}: {Value}", header.Key, header.Value);
+                    var firstSelector = await WaitForAnySelectorAsync(
+                        page,
+                        new[]
+                        {
+                            "a[href*='/shop/productdetails/']",
+                            "[data-testid*='product-tile']",
+                            "[data-testid*='product']"
+                        },
+                        20000);
+                    if (firstSelector is null)
+                    {
+                        _logger.LogWarning("WWS PROBE: no product selector detected within timeout.");
+                    }
+                    else
+                    {
+                        _logger.LogInformation("WWS PROBE: first product selector matched: {Selector}", firstSelector);
+                    }
                 }
 
-                var body = await resp.TextAsync();
+                var cookies = await context.CookiesAsync(new[] { SpecialsUrl });
+                if (cookies.Count > 0)
+                {
+                    _logger.LogInformation("WWS cookies: {Names}", string.Join(", ", cookies.Select(c => c.Name)));
+                }
+
+                if (probeOnly)
+                {
+                    probeResult = await ProbePageAsync(page, apiHits);
+                    return;
+                }
+
+                // Fetch API inside page context (closer to real browser behavior)
+                _logger.LogInformation("Fetching API via in-page fetch: {Url}", apiUrl);
+                var resp = await page.EvaluateAsync<ApiProbeResponse>(
+                    @"async (url) => {
+                        const res = await fetch(url, { credentials: 'include' });
+                        const text = await res.text();
+                        const headers = {};
+                        res.headers.forEach((v, k) => { headers[k] = v; });
+                        return { Status: res.status, Ok: res.ok, Url: res.url, Text: text, Headers: headers };
+                    }",
+                    apiUrl);
+
+                _logger.LogWarning("WWS API status={Status} ok={Ok} url={Url}", resp.Status, resp.Ok, resp.Url);
+                if (resp.Headers != null)
+                {
+                    foreach (var header in resp.Headers)
+                    {
+                        _logger.LogWarning("Header {Key}: {Value}", header.Key, header.Value);
+                    }
+                }
+
+                var body = resp.Text ?? string.Empty;
                 if (string.IsNullOrWhiteSpace(body))
                     throw new Exception("Empty response from Woolworths API");
+
+                if (IsAccessDeniedBody(body))
+                {
+                    var snippet = body.Length > 500 ? body[..500] : body;
+                    _logger.LogWarning("WWS API returned HTML/AccessDenied. Snippet: {Snippet}", snippet);
+                    throw new Exception("WWS API returned HTML/AccessDenied.");
+                }
 
                 // Parse JSON
                 var data = JsonSerializer.Deserialize<List<WoolworthsSpecialProductDto>>(body, _jsonOptions);
@@ -170,6 +269,20 @@ namespace PriceCompareCore.Services
                     throw new Exception("Failed to parse products list from Woolworths API");
                 }
             });
+
+            if (probeOnly)
+            {
+                if (probeResult != null)
+                {
+                    LogProbeResult(probeResult);
+                }
+                else
+                {
+                    _logger.LogWarning("WWS PROBE: no result (Playwright failed before probe).");
+                }
+
+                return new List<WoolworthsSpecialProduct>();
+            }
 
             // 3. Store price history
             foreach (var product in allProducts)
@@ -268,5 +381,193 @@ namespace PriceCompareCore.Services
             public Task<ScrapeExportResult?> ExportAsync(ScrapeExportRequest request, CancellationToken ct = default)
                 => Task.FromResult<ScrapeExportResult?>(null);
         }
+
+        private static string GetUserAgent()
+        {
+            var ua = Environment.GetEnvironmentVariable("WWS_USER_AGENT");
+            return string.IsNullOrWhiteSpace(ua) ? DefaultUa : ua.Trim();
+        }
+
+        private static string BuildSpecialsApiUrl()
+        {
+            var ids = Environment.GetEnvironmentVariable("WWS_PRODUCT_IDS");
+            if (!string.IsNullOrWhiteSpace(ids))
+            {
+                return $"https://www.woolworths.com.au/apis/ui/products/{ids}?excludeUnavailable=true";
+            }
+
+            var overrideUrl = Environment.GetEnvironmentVariable("WWS_SPECIALS_API_URL");
+            return string.IsNullOrWhiteSpace(overrideUrl) ? SpecialsApiUrl : overrideUrl.Trim();
+        }
+
+        private static int GetSlowMoMs()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_SLOWMO_MS");
+            return int.TryParse(raw, out var ms) && ms >= 0 ? ms : 60;
+        }
+
+        private static bool GetHeadless()
+        {
+            var headful = Environment.GetEnvironmentVariable("WWS_HEADFUL");
+            return !string.Equals(headful, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string? GetChromeChannel()
+        {
+            var useChrome = Environment.GetEnvironmentVariable("WWS_USE_CHROME_CHANNEL");
+            return string.Equals(useChrome, "true", StringComparison.OrdinalIgnoreCase) ? "chrome" : null;
+        }
+
+        private static bool IsAccessDeniedBody(string body)
+        {
+            var trimmed = body.TrimStart();
+            if (trimmed.StartsWith("<"))
+            {
+                return true;
+            }
+
+            return body.Contains("Access Denied", StringComparison.OrdinalIgnoreCase) ||
+                   body.Contains("Request blocked", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static async Task<string?> WaitForAnySelectorAsync(IPage page, IReadOnlyList<string> selectors, int timeoutMs)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                foreach (var selector in selectors)
+                {
+                    try
+                    {
+                        var count = await page.Locator(selector).CountAsync();
+                        if (count > 0)
+                        {
+                            return selector;
+                        }
+                    }
+                    catch
+                    {
+                        // ignore and keep polling
+                    }
+                }
+
+                await page.WaitForTimeoutAsync(500);
+            }
+
+            return null;
+        }
+
+        private static async Task HumanDelayAsync(IPage page, int minMs, int maxMs)
+        {
+            if (minMs < 0) minMs = 0;
+            if (maxMs < minMs) maxMs = minMs;
+            var delay = Random.Shared.Next(minMs, maxMs + 1);
+            await page.WaitForTimeoutAsync(delay);
+        }
+
+        private static async Task<bool> TryClickAsync(IPage page, string selector, int timeoutMs)
+        {
+            try
+            {
+                await page.ClickAsync(selector, new PageClickOptions { Timeout = timeoutMs });
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private sealed class ApiProbeResponse
+        {
+            public int Status { get; set; }
+            public bool Ok { get; set; }
+            public string? Url { get; set; }
+            public string? Text { get; set; }
+            public Dictionary<string, string>? Headers { get; set; }
+        }
+
+        private static string GetStealthScript()
+        {
+            return @"
+// webdriver
+Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+// languages
+Object.defineProperty(navigator, 'languages', { get: () => ['en-AU', 'en'] });
+// plugins
+Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+// chrome runtime
+window.chrome = window.chrome || { runtime: {} };
+// permissions
+const originalQuery = window.navigator.permissions.query;
+window.navigator.permissions.query = (parameters) => (
+  parameters.name === 'notifications'
+    ? Promise.resolve({ state: Notification.permission })
+    : originalQuery(parameters)
+);
+";
+        }
+
+        private static bool GetProbeOnly()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_PROBE_ONLY");
+            return string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static async Task<WwsProbeResult> ProbePageAsync(IPage page, IReadOnlyList<ApiHit> apiHits)
+        {
+            await HumanDelayAsync(page, 800, 1400);
+            await page.Mouse.WheelAsync(0, 1400);
+            await HumanDelayAsync(page, 800, 1400);
+
+            var productLinks = await page.Locator("a[href*='/shop/productdetails/']").CountAsync();
+            var productTiles = await page.Locator("[data-testid*='product-tile']").CountAsync();
+            var productTestIds = await page.Locator("[data-testid*='product']").CountAsync();
+
+            var html = await page.ContentAsync();
+            var denied = html.Contains("Access Denied", StringComparison.OrdinalIgnoreCase) ||
+                         html.Contains("Request blocked", StringComparison.OrdinalIgnoreCase);
+            var snippet = denied ? html[..Math.Min(500, html.Length)] : null;
+
+            var apiTotal = apiHits.Count;
+            var api403 = apiHits.Count(h => h.Status == 403);
+
+            return new WwsProbeResult(
+                productLinks,
+                productTiles,
+                productTestIds,
+                apiTotal,
+                api403,
+                denied,
+                snippet);
+        }
+
+        private void LogProbeResult(WwsProbeResult result)
+        {
+            _logger.LogInformation(
+                "WWS PROBE: links={Links} tiles={Tiles} testIdProducts={TestIds} apiRequests={ApiTotal} api403={Api403} accessDeniedHtml={Denied}",
+                result.ProductLinkCount,
+                result.ProductTileCount,
+                result.ProductTestIdCount,
+                result.ApiRequestCount,
+                result.Api403Count,
+                result.AccessDeniedInHtml);
+
+            if (result.AccessDeniedInHtml && !string.IsNullOrWhiteSpace(result.HtmlSnippet))
+            {
+                _logger.LogWarning("WWS PROBE: HTML snippet: {Snippet}", result.HtmlSnippet);
+            }
+        }
+
+        private sealed record ApiHit(int Status, string Url);
+
+        private sealed record WwsProbeResult(
+            int ProductLinkCount,
+            int ProductTileCount,
+            int ProductTestIdCount,
+            int ApiRequestCount,
+            int Api403Count,
+            bool AccessDeniedInHtml,
+            string? HtmlSnippet);
     }
 }

--- a/src/PriceCompareWeb/Controllers/ScrapingController.cs
+++ b/src/PriceCompareWeb/Controllers/ScrapingController.cs
@@ -17,16 +17,19 @@ namespace PriceCompareWeb.Controllers
         private readonly IColesSpecialScraperService _specialScraperService;
         private readonly ILogger<ScrapingController> _logger;
         private readonly IWoolworthsSpecialScraperService _wscraperService;
+        private readonly IWoolworthsLowerShelfDomScraperService _wwsLowerShelfDomService;
 
         public ScrapingController(IColesDownScraperService scraperService,
         ILogger<ScrapingController> logger,
         IColesSpecialScraperService specialScraperService,
-        IWoolworthsSpecialScraperService wscraperService)
+        IWoolworthsSpecialScraperService wscraperService,
+        IWoolworthsLowerShelfDomScraperService wwsLowerShelfDomService)
         {
             _scraperService = scraperService;
             _logger = logger;
             _specialScraperService = specialScraperService;
             _wscraperService = wscraperService;
+            _wwsLowerShelfDomService = wwsLowerShelfDomService;
         }
 
         [HttpGet("coles/down-down/all")]
@@ -92,6 +95,25 @@ namespace PriceCompareWeb.Controllers
             {
                 _logger.LogError(ex, "Failed to get Woolworths on-special products");
                 return StatusCode(500, "Failed to get Woolworths on-special products");
+            }
+        }
+
+        [HttpGet("woolworths/lower-shelf/dom")]
+        public async Task<IActionResult> GetWoolworthsLowerShelfDom([FromQuery] int limit = 20)
+        {
+            try
+            {
+                var products = await _wwsLowerShelfDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Woolworths lower-shelf-price DOM products");
+                return StatusCode(500, "Failed to get Woolworths lower-shelf-price DOM products");
             }
         }
 

--- a/src/PriceCompareWeb/Program.cs
+++ b/src/PriceCompareWeb/Program.cs
@@ -161,7 +161,9 @@ if (enableQuartzJobs)
         q.AddTrigger(opts => opts
             .ForJob(favoriteTrackJobKey)
             .WithIdentity("FavoritePriceTrackingJob-trigger")
-            .WithCronSchedule("0 0 5 ? * WED"));
+        // testing
+        // .WithCronSchedule("0 */1 * ? * *"));
+        .WithCronSchedule("0 0 5 ? * WED"));
     });
 
     builder.Services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
@@ -179,6 +181,7 @@ builder.Services.AddHttpClient<IColesDownScraperService, ColesDownScraperService
 builder.Services.AddScoped<IColesSpecialScraperService, ColesSpecialScraperService>();
 
 builder.Services.AddScoped<IWoolworthsSpecialScraperService, WoolworthsSpecialScraperService>();
+builder.Services.AddScoped<IWoolworthsLowerShelfDomScraperService, WoolworthsLowerShelfDomScraperService>();
 
 builder.Services.AddScoped<ICategoryMappingService, CategoryMappingService>();
 


### PR DESCRIPTION
Work Done:

Implemented a Playwright DOM scraper for Woolworths lower-shelf-price to avoid API-layer WAF blocks.

Added a dedicated service and endpoint GET /api/Scraping/woolworths/lower-shelf/dom without touching existing WWS API flow.

Implemented pageNumber pagination, light scrolling for lazy content, de-duplication, and invalid entry filtering.

Parsed product name and price from aria-label to work around Shadow DOM.

Related Jira Key: BTS-90