### PR TITLE
BTS-93: Fixed bugs - Compare dialog shows incorrect target shop and misses WWS LOWER_SHELF weekly trend data

### DIFF
--- a/client/web/src/api/compare.ts
+++ b/client/web/src/api/compare.ts
@@ -36,9 +36,9 @@ function normalizeProduct(raw: any): CompareProduct {
 		"CurrentPrice",
 	);
 	const productId = read<string>(raw, "productId", "ProductId");
-	const shopType = Number(
-		read<number | string>(raw, "shopType", "ShopType"),
-	) as number;
+	const shopTypeRaw = read<number | string>(raw, "shopType", "ShopType");
+	const shopTypeNum = Number(shopTypeRaw);
+	const shopType = Number.isFinite(shopTypeNum) ? shopTypeNum : NaN;
 	const brand = read<string | null>(raw, "brand", "Brand") ?? null;
 	const sizeExisting = read<string | null>(raw, "size", "Size");
 	let size = sizeExisting ?? null;
@@ -87,7 +87,9 @@ export async function fetchCompareMatches(
 	const rawSource = read<any>(match, "source", "Source");
 	const rawTargets = read<any[]>(match, "targets", "Targets") ?? [];
 	const source = normalizeProduct(rawSource);
-	const targets = rawTargets.map(normalizeProduct);
+	const targets = rawTargets
+		.map(normalizeProduct)
+		.filter((t) => !Number.isFinite(source.shopType) || t.shopType !== source.shopType);
 	return { source, targets };
 }
 
@@ -118,13 +120,16 @@ export async function fetchMergedHistory(
 	name: string,
 	shopType: number,
 ): Promise<PriceHistoryPoint[]> {
-	const [a, b] = await Promise.allSettled([
-		fetchPriceHistory(name, shopType, 0),
-		fetchPriceHistory(name, shopType, 1),
-	]);
+	const requests = [0, 1, 2].map((offerType) =>
+		fetchPriceHistory(name, shopType, offerType),
+	);
+	const settled = await Promise.allSettled(requests);
 	const list: PriceHistoryPoint[] = [];
-	if (a.status === "fulfilled") list.push(...a.value);
-	if (b.status === "fulfilled") list.push(...b.value);
+	for (const result of settled) {
+		if (result.status === "fulfilled") {
+			list.push(...result.value);
+		}
+	}
 	// dedupe by timestamp; keep the lowest price for the same timestamp
 	const map = new Map<string, number>();
 	for (const p of list) {

--- a/client/web/src/components/CompareDialog.tsx
+++ b/client/web/src/components/CompareDialog.tsx
@@ -135,6 +135,15 @@ export default function CompareDialog(props: CompareDialogProps) {
 
 	const [seriesLoading, setSeriesLoading] = React.useState(false);
 	const [series, setSeries] = React.useState<PairedSeriesPoint[]>([]);
+	const fallbackTargetShop = React.useMemo(() => {
+		if (!source) return undefined;
+		return source.shopType === ShopTypes.COLES
+			? ShopTypes.WOOLWORTHS
+			: source.shopType === ShopTypes.WOOLWORTHS
+				? ShopTypes.COLES
+				: undefined;
+	}, [source]);
+	const targetShopForTitle = selectedTarget?.shopType ?? fallbackTargetShop;
 
 	React.useEffect(() => {
 		let cancelled = false;
@@ -213,14 +222,22 @@ export default function CompareDialog(props: CompareDialogProps) {
 								/>
 								<PriceCard
 									title={
-										selectedTarget?.shopType === ShopTypes.COLES
+										targetShopForTitle === ShopTypes.COLES
 											? "Target · Coles"
-											: "Target · Woolworths"
+											: targetShopForTitle === ShopTypes.WOOLWORTHS
+												? "Target · Woolworths"
+												: "Target"
 									}
 									item={selectedTarget}
 									accent="#22c55e"
 								/>
 							</Stack>
+
+							{targets.length === 0 && (
+								<Typography variant="body2" color="text.secondary">
+									No matched product found in the other shop yet.
+								</Typography>
+							)}
 
 							{targets.length > 1 && (
 								<Stack
@@ -304,6 +321,10 @@ export default function CompareDialog(props: CompareDialogProps) {
 									>
 										<CircularProgress size={24} />
 									</Stack>
+								) : series.length === 0 ? (
+									<Typography variant="body2" color="text.secondary">
+										No price history yet.
+									</Typography>
 								) : (
 									<ResponsiveContainer>
 										<LineChart
@@ -324,7 +345,7 @@ export default function CompareDialog(props: CompareDialogProps) {
 												dataKey="source"
 												name="Source"
 												stroke="#0ea5e9"
-												dot={false}
+												dot={series.length <= 1}
 												strokeWidth={2}
 											/>
 											<Line
@@ -332,7 +353,7 @@ export default function CompareDialog(props: CompareDialogProps) {
 												dataKey="target"
 												name="Target"
 												stroke="#22c55e"
-												dot={false}
+												dot={series.length <= 1}
 												strokeWidth={2}
 											/>
 										</LineChart>


### PR DESCRIPTION
Description
When filtering Woolworths products and opening the Compare dialog, we observed:
Target shop label can appear as the same shop as Source (misleading UI).
Weekly Trend shows no prices for products that only have LOWER_SHELF history.
Chart appears blank when there is only one data point.

Impact
Users can misinterpret cross-shop comparison results.
Users think no history exists when data is actually present.
Core compare experience is degraded.

Root Cause
When selectedTarget is empty, target title logic defaulted to Woolworths ([CompareDialog.tsx (line 225)]
Chart used dot={false}, so single-point series looked empty.


BTS-93