### PR TITLE
BTS-99: Redesigned products page cards with image fallback and shop accents.

### DIFF
--- a/client/web/src/ProductsPage.tsx
+++ b/client/web/src/ProductsPage.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { useState, useEffect } from "react";
 import Box from "@mui/material/Box";
-import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
 import {
 	TextField,
 	Button,
@@ -10,6 +9,13 @@ import {
 	InputLabel,
 	Select,
 	MenuItem,
+	Typography,
+	Card,
+	CardContent,
+	Chip,
+	Pagination,
+	LinearProgress,
+	Divider,
 } from "@mui/material";
 import { useMediaQuery, useTheme } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material/Select";
@@ -17,6 +23,89 @@ import { SHOP_OPTIONS, shopTypeName } from "./constants/shopTypes";
 import { fetchProducts, type ProductRow } from "./api/products";
 import { useDebounce } from "./hooks/useDebounce";
 import CompareDialog from "./components/CompareDialog";
+
+function formatSizeValue(value?: number | null) {
+	return value == null || Number.isNaN(value) ? "-" : String(value);
+}
+
+function formatSizeUnit(value?: string | null) {
+	return value && value.trim() !== "" ? value : "-";
+}
+
+function formatSize(row: ProductRow) {
+	if (row.size && row.size.trim() !== "") return row.size;
+	const v = row.sizeValue;
+	const u = row.sizeUnit;
+	if (v != null && u) return `${v} ${u}`;
+	if (v != null) return String(v);
+	if (u) return u;
+	return "";
+}
+
+function formatPrice(price?: number, sizeText?: string) {
+	if (price == null || !Number.isFinite(price)) return "-";
+	const base = `$${price.toFixed(2)}`;
+	if (sizeText) return `${base} / ${sizeText}`;
+	return `${base} AUD`;
+}
+
+function shopAccent(shopType?: number | string | null) {
+	if (shopType === 0 || shopType === "0") return "#c93925";
+	if (shopType === 1 || shopType === "1") return "#3f8149";
+	return "#4b5563";
+}
+
+function ProductImage({
+	src,
+	alt,
+}: {
+	src?: string | null;
+	alt: string;
+}) {
+	const [failed, setFailed] = React.useState(false);
+	if (!src || failed) {
+		const initial =
+			alt && alt.trim() !== "" ? alt.trim().charAt(0).toUpperCase() : "?";
+		return (
+			<Box
+				sx={{
+					height: 170,
+					borderRadius: 2.5,
+					bgcolor: "#f5f5f7",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+				}}
+			>
+				<Box
+					sx={{
+						color: "#111111",
+						fontSize: 48,
+						fontWeight: 600,
+					}}
+				>
+					{initial}
+				</Box>
+			</Box>
+		);
+	}
+
+	return (
+		<Box
+			component="img"
+			src={src}
+			alt={alt}
+			onError={() => setFailed(true)}
+			sx={{
+				height: 170,
+				width: "100%",
+				objectFit: "contain",
+				borderRadius: 2.5,
+				backgroundColor: "#ffffff",
+			}}
+		/>
+	);
+}
 
 export default function ProductsPage() {
 	const theme = useTheme();
@@ -27,7 +116,7 @@ export default function ProductsPage() {
 	const [loading, setLoading] = useState(false);
 	const [search, setSearch] = useState("");
 	const [shopType, setShopType] = useState("");
-	const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+	const [paginationModel, setPaginationModel] = useState({
 		page: 0,
 		pageSize: 20,
 	});
@@ -93,56 +182,13 @@ export default function ProductsPage() {
 		refreshTick,
 	]);
 
-	const columns: GridColDef<ProductRow>[] = [
-		{ field: "productId", headerName: "ID", width: 200 },
-		{
-			field: "name",
-			headerName: "Product Name",
-			flex: 1,
-			minWidth: isXs ? 160 : 220,
-		},
-		{ field: "price", headerName: "Price", width: 100 },
-		{
-			field: "shopType",
-			headerName: "Shop",
-			width: 120,
-			renderCell: (params) => shopTypeName((params as any).row?.shopType),
-		},
-		{ field: "size", headerName: "Size", width: 120 },
-		{
-			field: "compare",
-			headerName: "Compare",
-			width: 120,
-			sortable: false,
-			renderCell: (params) => (
-				<Button
-					variant="contained"
-					size="small"
-					color="primary"
-					onClick={() =>
-						handleCompare(
-							params.row.productId,
-							params.row.name,
-							params.row.shopType,
-						)
-					}
-				>
-					Compare
-				</Button>
-			),
-		},
-	];
-
-	const columnVisibilityModel = React.useMemo(
-		() => ({
-			productId: !isMdDown, // 隐藏 ID 在中小屏
-			size: !isXs, // 超小屏隐藏 Size 列
-		}),
-		[isMdDown, isXs],
+	const totalPages = Math.max(
+		1,
+		Math.ceil(rowCount / Math.max(1, paginationModel.pageSize)),
 	);
 
 	return (
-		<Box sx={{ height: isXs ? "auto" : 600, width: "100%", p: { xs: 1.5, sm: 3 } }}>
+		<Box sx={{ width: "100%" }}>
 			<Stack direction={{ xs: "column", sm: "row" }} spacing={2} sx={{ mb: 2 }}>
 				<TextField
 					label="Search by name"
@@ -157,7 +203,11 @@ export default function ProductsPage() {
 						);
 					}}
 				/>
-				<FormControl size="small" sx={{ minWidth: { xs: "100%", sm: 160 } }} fullWidth={isXs}>
+				<FormControl
+					size="small"
+					sx={{ minWidth: { xs: "100%", sm: 160 } }}
+					fullWidth={isXs}
+				>
 					<InputLabel id="shop-type-label">Shop</InputLabel>
 					<Select
 						labelId="shop-type-label"
@@ -189,21 +239,223 @@ export default function ProductsPage() {
 				</Button>
 			</Stack>
 
-			<DataGrid
-				rows={rows}
-				columns={columns}
-				columnVisibilityModel={columnVisibilityModel}
-				getRowId={(row) => row.productId}
-				loading={loading}
-				pagination
-				paginationMode="server"
-				paginationModel={paginationModel}
-				onPaginationModelChange={(model) => setPaginationModel(model)}
-				rowCount={rowCount}
-				pageSizeOptions={[10, 20, 50]}
-				disableRowSelectionOnClick
-				autoHeight={isXs}
-			/>
+			<Box
+				sx={{
+					position: "relative",
+					borderRadius: 4,
+					border: "1px solid #edf1f5",
+					bgcolor: "#fafafa",
+					p: { xs: 1.5, sm: 2.5 },
+					overflow: "hidden",
+				}}
+			>
+				{loading && (
+					<LinearProgress
+						sx={{
+							position: "absolute",
+							left: 0,
+							right: 0,
+							top: 0,
+						}}
+					/>
+				)}
+				{rows.length === 0 && !loading ? (
+					<Box
+						sx={{
+							py: 8,
+							textAlign: "center",
+							color: "text.secondary",
+						}}
+					>
+						<Typography variant="body1" sx={{ fontWeight: 600 }}>
+							No products found
+						</Typography>
+						<Typography variant="body2">
+							Try adjusting your filters.
+						</Typography>
+					</Box>
+				) : (
+					<Box
+						sx={{
+							display: "grid",
+							gridTemplateColumns: {
+								xs: "1fr",
+								sm: "repeat(2, minmax(0, 1fr))",
+								md: "repeat(3, minmax(0, 1fr))",
+								lg: "repeat(4, minmax(0, 1fr))",
+							},
+							gap: { xs: 2, sm: 2.5, md: 3 },
+						}}
+					>
+						{rows.map((row) => {
+							const sizeText = formatSize(row);
+							const priceText = formatPrice(row.price, sizeText || undefined);
+							const accent = shopAccent(row.shopType);
+							return (
+								<Card
+									key={row.productId}
+									elevation={0}
+									sx={{
+										display: "flex",
+										flexDirection: "column",
+										borderRadius: 3.5,
+										border: "1px solid #e8edf2",
+										bgcolor: "#ffffff",
+										boxShadow: "0 18px 40px rgba(15, 23, 42, 0.08)",
+									}}
+								>
+									<Box
+											sx={{
+											px: 2.5,
+											pt: 2.5,
+											pb: 2,
+											background:
+												"linear-gradient(180deg, #f5f5f7 0%, #ffffff 100%)",
+										}}
+									>
+										<ProductImage src={row.imageUrl} alt={row.name} />
+									</Box>
+									<CardContent
+											sx={{
+											flex: 1,
+											display: "flex",
+											flexDirection: "column",
+											gap: 1.2,
+											pt: 2,
+											alignItems: "center",
+											textAlign: "center",
+										}}
+									>
+										<Typography
+											variant="subtitle1"
+											fontWeight={700}
+											sx={{
+												minHeight: 48,
+												display: "-webkit-box",
+												WebkitLineClamp: 2,
+												WebkitBoxOrient: "vertical",
+												overflow: "hidden",
+												width: "100%",
+											}}
+										>
+											{row.name || "-"}
+										</Typography>
+										<Stack
+											direction="row"
+											spacing={1}
+											useFlexGap
+											flexWrap="wrap"
+											justifyContent="center"
+										>
+											<Chip
+												size="small"
+												label={shopTypeName(row.shopType)}
+												color="default"
+												sx={{
+													fontWeight: 600,
+													color: "#ffffff",
+													bgcolor: accent,
+												}}
+											/>
+											{sizeText && (
+												<Chip
+													size="small"
+													variant="outlined"
+													label={`Size ${sizeText}`}
+													sx={{ borderColor: accent, color: accent }}
+												/>
+											)}
+										</Stack>
+										<Box>
+											<Typography variant="caption" color="text.secondary">
+												Price (with unit)
+											</Typography>
+											<Typography
+												variant="h6"
+												fontWeight={700}
+												sx={{ color: accent }}
+											>
+												{priceText}
+											</Typography>
+										</Box>
+										<Divider />
+										<Stack spacing={0.3}>
+											<Typography variant="body2" color="text.secondary">
+												Size value: {formatSizeValue(row.sizeValue)}
+											</Typography>
+											<Typography variant="body2" color="text.secondary">
+												Size unit: {formatSizeUnit(row.sizeUnit)}
+											</Typography>
+										</Stack>
+										<Button
+											variant="contained"
+											size="small"
+											sx={{ mt: "auto", alignSelf: "center" }}
+											onClick={() =>
+												handleCompare(
+													row.productId,
+													row.name,
+													row.shopType,
+												)
+											}
+										>
+											Compare
+										</Button>
+									</CardContent>
+								</Card>
+							);
+						})}
+					</Box>
+				)}
+			</Box>
+
+			<Stack
+				direction={{ xs: "column", sm: "row" }}
+				spacing={2}
+				sx={{ mt: 2 }}
+				alignItems={{ xs: "stretch", sm: "center" }}
+				justifyContent="space-between"
+			>
+				<Typography variant="body2" color="text.secondary">
+					{rowCount} products
+				</Typography>
+				<Stack
+					direction={{ xs: "column", sm: "row" }}
+					spacing={2}
+					alignItems={{ xs: "stretch", sm: "center" }}
+				>
+					<Pagination
+						count={totalPages}
+						page={paginationModel.page + 1}
+						onChange={(_, page) =>
+							setPaginationModel((prev) => ({
+								...prev,
+								page: page - 1,
+							}))
+						}
+						color="primary"
+						size={isMdDown ? "small" : "medium"}
+					/>
+					<FormControl size="small" sx={{ minWidth: 120 }}>
+						<InputLabel id="page-size-label">Page size</InputLabel>
+						<Select
+							labelId="page-size-label"
+							label="Page size"
+							value={String(paginationModel.pageSize)}
+							onChange={(e) => {
+								const nextSize = Number(e.target.value);
+								setPaginationModel({ page: 0, pageSize: nextSize });
+							}}
+						>
+							{[10, 20, 50].map((opt) => (
+								<MenuItem key={opt} value={String(opt)}>
+									{opt}
+								</MenuItem>
+							))}
+						</Select>
+					</FormControl>
+				</Stack>
+			</Stack>
 
 			<CompareDialog
 				open={compareOpen}

--- a/client/web/src/api/products.ts
+++ b/client/web/src/api/products.ts
@@ -9,6 +9,7 @@ export interface ProductRow {
 	shopType?: number | string | null;
 	sizeValue?: number | null;
 	sizeUnit?: string | null;
+	imageUrl?: string | null;
 	// Combined size string for display, e.g. "500 g" or "2 L"
 	size?: string | null;
 }
@@ -36,8 +37,10 @@ export async function fetchProducts(
 	const rawItems: ProductRow[] = data.products ?? data.Products ?? [];
 	// Build combined size field on the client for compatibility with different backends
 	const items: ProductRow[] = rawItems.map((it) => {
+		const imageUrl =
+			(it as any).imageUrl ?? (it as any).ImageUrl ?? it.imageUrl ?? null;
 		const sizeExisting = (it as any).size ?? (it as any).Size;
-		if (sizeExisting) return { ...it, size: sizeExisting };
+		if (sizeExisting) return { ...it, imageUrl, size: sizeExisting };
 
 		const v = it.sizeValue;
 		const u = it.sizeUnit;
@@ -50,7 +53,7 @@ export async function fetchProducts(
 		} else if (u != null) {
 			size = u;
 		}
-		return { ...it, size };
+		return { ...it, imageUrl, size };
 	});
 	const total: number = data.count ?? data.Count ?? 0;
 


### PR DESCRIPTION
Replace DataGrid with centered card layout, add imageUrl support, and apply shop-specific colors while keeping compare action.

Related Jira Key: BTS-99