### PR TITLE
BTS-101: add Coles DOM category scrapers, schedules, and sequential lock

### DIFF
--- a/src/PriceCompareCore/Interfaces/IColesBabyDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesBabyDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesBabyDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesBakeryDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesBakeryDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesBakeryDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesBigPackValueDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesBigPackValueDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesBigPackValueDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesBonusCreditProductsDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesBonusCreditProductsDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesBonusCreditProductsDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesChipsChocolatesSnacksDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesChipsChocolatesSnacksDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesChipsChocolatesSnacksDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesCleaningLaundryDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesCleaningLaundryDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesCleaningLaundryDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesDairyEggsFridgeDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesDairyEggsFridgeDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesDairyEggsFridgeDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesDeliDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesDeliDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesDeliDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesDeliverMoreRangeDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesDeliverMoreRangeDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesDeliverMoreRangeDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesDietaryWorldFoodsDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesDietaryWorldFoodsDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesDietaryWorldFoodsDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesDrinksDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesDrinksDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesDrinksDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesFrozenDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesFrozenDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesFrozenDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesFruitVegetablesDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesFruitVegetablesDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesFruitVegetablesDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesHealthBeautyDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesHealthBeautyDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesHealthBeautyDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesHomeGardenDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesHomeGardenDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesHomeGardenDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesLiquorlandDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesLiquorlandDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesLiquorlandDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesMeatSeafoodDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesMeatSeafoodDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesMeatSeafoodDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesPantryDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesPantryDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesPantryDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Interfaces/IColesPetDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IColesPetDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IColesPetDomScraperService
+    {
+        Task<List<ColesDownProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesBabyDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesBabyDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesBabyDomJob : IJob
+    {
+        private readonly IColesBabyDomScraperService _scraperService;
+
+        public ColesBabyDomJob(IColesBabyDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesBigPackValueDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesBigPackValueDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesBigPackValueDomJob : IJob
+    {
+        private readonly IColesBigPackValueDomScraperService _scraperService;
+
+        public ColesBigPackValueDomJob(IColesBigPackValueDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesBonusCreditProductsDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesBonusCreditProductsDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesBonusCreditProductsDomJob : IJob
+    {
+        private readonly IColesBonusCreditProductsDomScraperService _scraperService;
+
+        public ColesBonusCreditProductsDomJob(IColesBonusCreditProductsDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesChipsChocolatesSnacksDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesChipsChocolatesSnacksDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesChipsChocolatesSnacksDomJob : IJob
+    {
+        private readonly IColesChipsChocolatesSnacksDomScraperService _scraperService;
+
+        public ColesChipsChocolatesSnacksDomJob(IColesChipsChocolatesSnacksDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesCleaningLaundryDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesCleaningLaundryDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesCleaningLaundryDomJob : IJob
+    {
+        private readonly IColesCleaningLaundryDomScraperService _scraperService;
+
+        public ColesCleaningLaundryDomJob(IColesCleaningLaundryDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesDeliverMoreRangeDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesDeliverMoreRangeDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesDeliverMoreRangeDomJob : IJob
+    {
+        private readonly IColesDeliverMoreRangeDomScraperService _scraperService;
+
+        public ColesDeliverMoreRangeDomJob(IColesDeliverMoreRangeDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesDietaryWorldFoodsDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesDietaryWorldFoodsDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesDietaryWorldFoodsDomJob : IJob
+    {
+        private readonly IColesDietaryWorldFoodsDomScraperService _scraperService;
+
+        public ColesDietaryWorldFoodsDomJob(IColesDietaryWorldFoodsDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesDomJobLock.cs
+++ b/src/PriceCompareCore/Jobs/ColesDomJobLock.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    internal static class ColesDomJobLock
+    {
+        public static readonly SemaphoreSlim Gate = new(1, 1);
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesDrinksDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesDrinksDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesDrinksDomJob : IJob
+    {
+        private readonly IColesDrinksDomScraperService _scraperService;
+
+        public ColesDrinksDomJob(IColesDrinksDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesFrozenDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesFrozenDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesFrozenDomJob : IJob
+    {
+        private readonly IColesFrozenDomScraperService _scraperService;
+
+        public ColesFrozenDomJob(IColesFrozenDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesHealthBeautyDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesHealthBeautyDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesHealthBeautyDomJob : IJob
+    {
+        private readonly IColesHealthBeautyDomScraperService _scraperService;
+
+        public ColesHealthBeautyDomJob(IColesHealthBeautyDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesHomeGardenDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesHomeGardenDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesHomeGardenDomJob : IJob
+    {
+        private readonly IColesHomeGardenDomScraperService _scraperService;
+
+        public ColesHomeGardenDomJob(IColesHomeGardenDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesLiquorlandDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesLiquorlandDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesLiquorlandDomJob : IJob
+    {
+        private readonly IColesLiquorlandDomScraperService _scraperService;
+
+        public ColesLiquorlandDomJob(IColesLiquorlandDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Jobs/ColesPetDomJob.cs
+++ b/src/PriceCompareCore/Jobs/ColesPetDomJob.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+using System.Threading;
+
+namespace PriceCompareCore.Jobs
+{
+    public class ColesPetDomJob : IJob
+    {
+        private readonly IColesPetDomScraperService _scraperService;
+
+        public ColesPetDomJob(IColesPetDomScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try
+            {
+                await _scraperService.ScrapeAsync(0, context.CancellationToken);
+            }
+            finally
+            {
+                ColesDomJobLock.Gate.Release();
+            }
+        }
+    }
+}

--- a/src/PriceCompareCore/Services/ColesBabyDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesBabyDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesBabyDomScraperService : IColesBabyDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/baby.json?slug=baby";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesBabyDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesBabyDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesBabyDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_BABY_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached baby products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_BABY_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesBabyApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesBabyApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.BABY &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.BABY,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_baby_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesBabyApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesBabyApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_BABY_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_BABY_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_BABY_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesBabyApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesBabyPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesBabyPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesBabySearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesBabySearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesBabyApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesBabyApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesBabyImageUri>? ImageUris { get; set; }
+            public ColesBabyPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesBabyPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesBabyUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesBabyUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesBabyImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesBakeryDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesBakeryDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesBakeryDomScraperService : IColesBakeryDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/bakery.json?slug=bakery";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesBakeryDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesBakeryDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesBakeryDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_BAKERY_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached bakery products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_BAKERY_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesBakeryApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesBakeryApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.BAKERY &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.BAKERY,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_bakery_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesBakeryApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesBakeryApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,7 +377,7 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_BAKERY_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
@@ -389,19 +389,19 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_BAKERY_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 3000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_BAKERY_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesBakeryApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesBakeryPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesBakeryPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesBakerySearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesBakerySearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesBakeryApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesBakeryApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesBakeryImageUri>? ImageUris { get; set; }
+            public ColesBakeryPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesBakeryPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesBakeryUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesBakeryUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesBakeryImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesBigPackValueDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesBigPackValueDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesBigPackValueDomScraperService : IColesBigPackValueDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/big-pack-value.json?slug=big-pack-value";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesBigPackValueDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesBigPackValueDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesBigPackValueDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_BIG_PACK_VALUE_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached big pack value products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_BIG_PACK_VALUE_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesBigPackValueApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesBigPackValueApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.BIG_PACK_VALUE &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.BIG_PACK_VALUE,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_big_pack_value_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesBigPackValueApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesBigPackValueApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_BIG_PACK_VALUE_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_BIG_PACK_VALUE_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_BIG_PACK_VALUE_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesBigPackValueApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesBigPackValuePageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesBigPackValuePageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesBigPackValueSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesBigPackValueSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesBigPackValueApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesBigPackValueApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesBigPackValueImageUri>? ImageUris { get; set; }
+            public ColesBigPackValuePricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesBigPackValuePricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesBigPackValueUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesBigPackValueUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesBigPackValueImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesBonusCreditProductsDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesBonusCreditProductsDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesBonusCreditProductsDomScraperService : IColesBonusCreditProductsDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/bonus-credit-products.json?slug=bonus-credit-products";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesBonusCreditProductsDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesBonusCreditProductsDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesBonusCreditProductsDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_BONUS_CREDIT_PRODUCTS_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached bonus credit products products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_BONUS_CREDIT_PRODUCTS_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesBonusCreditProductsApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesBonusCreditProductsApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.BONUS_CREDIT_PRODUCTS &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.BONUS_CREDIT_PRODUCTS,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_bonus_credit_products_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesBonusCreditProductsApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesBonusCreditProductsApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_BONUS_CREDIT_PRODUCTS_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_BONUS_CREDIT_PRODUCTS_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_BONUS_CREDIT_PRODUCTS_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesBonusCreditProductsApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesBonusCreditProductsPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesBonusCreditProductsPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesBonusCreditProductsSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesBonusCreditProductsSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesBonusCreditProductsApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesBonusCreditProductsApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesBonusCreditProductsImageUri>? ImageUris { get; set; }
+            public ColesBonusCreditProductsPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesBonusCreditProductsPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesBonusCreditProductsUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesBonusCreditProductsUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesBonusCreditProductsImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesChipsChocolatesSnacksDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesChipsChocolatesSnacksDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesChipsChocolatesSnacksDomScraperService : IColesChipsChocolatesSnacksDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/chips-chocolates-snacks.json?slug=chips-chocolates-snacks";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesChipsChocolatesSnacksDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesChipsChocolatesSnacksDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesChipsChocolatesSnacksDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_CHIPS_CHOCOLATES_SNACKS_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached chips, chocolates & snacks products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_CHIPS_CHOCOLATES_SNACKS_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesChipsChocolatesSnacksApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesChipsChocolatesSnacksApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.CHIPS_CHOCOLATES_SNACKS &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.CHIPS_CHOCOLATES_SNACKS,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_chips_chocolates_snacks_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesChipsChocolatesSnacksApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesChipsChocolatesSnacksApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_CHIPS_CHOCOLATES_SNACKS_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_CHIPS_CHOCOLATES_SNACKS_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_CHIPS_CHOCOLATES_SNACKS_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesChipsChocolatesSnacksApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesChipsChocolatesSnacksPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesChipsChocolatesSnacksPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesChipsChocolatesSnacksSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesChipsChocolatesSnacksSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesChipsChocolatesSnacksApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesChipsChocolatesSnacksApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesChipsChocolatesSnacksImageUri>? ImageUris { get; set; }
+            public ColesChipsChocolatesSnacksPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesChipsChocolatesSnacksPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesChipsChocolatesSnacksUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesChipsChocolatesSnacksUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesChipsChocolatesSnacksImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesCleaningLaundryDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesCleaningLaundryDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesCleaningLaundryDomScraperService : IColesCleaningLaundryDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/cleaning-laundry.json?slug=cleaning-laundry";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesCleaningLaundryDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesCleaningLaundryDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesCleaningLaundryDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_CLEANING_LAUNDRY_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached cleaning & laundry products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_CLEANING_LAUNDRY_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesCleaningLaundryApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesCleaningLaundryApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.CLEANING_LAUNDRY &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.CLEANING_LAUNDRY,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_cleaning_laundry_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesCleaningLaundryApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesCleaningLaundryApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_CLEANING_LAUNDRY_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_CLEANING_LAUNDRY_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_CLEANING_LAUNDRY_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesCleaningLaundryApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesCleaningLaundryPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesCleaningLaundryPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesCleaningLaundrySearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesCleaningLaundrySearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesCleaningLaundryApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesCleaningLaundryApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesCleaningLaundryImageUri>? ImageUris { get; set; }
+            public ColesCleaningLaundryPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesCleaningLaundryPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesCleaningLaundryUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesCleaningLaundryUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesCleaningLaundryImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesDairyEggsFridgeDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesDairyEggsFridgeDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesDairyEggsFridgeDomScraperService : IColesDairyEggsFridgeDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/dairy-eggs-fridge.json?slug=dairy-eggs-fridge";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesDairyEggsFridgeDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesDairyEggsFridgeDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesDairyEggsFridgeDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DAIRY_EGGS_FRIDGE_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached dairy, eggs & fridge products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_DAIRY_EGGS_FRIDGE_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesDairyEggsFridgeApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesDairyEggsFridgeApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.DAIRY_EGGS_FRIDGE &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.DAIRY_EGGS_FRIDGE,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_dairy_eggs_fridge_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesDairyEggsFridgeApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesDairyEggsFridgeApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,7 +377,7 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_DAIRY_EGGS_FRIDGE_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
@@ -389,19 +389,19 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_DAIRY_EGGS_FRIDGE_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 3000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_DAIRY_EGGS_FRIDGE_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesDairyEggsFridgeApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesDairyEggsFridgePageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesDairyEggsFridgePageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesDairyEggsFridgeSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesDairyEggsFridgeSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesDairyEggsFridgeApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesDairyEggsFridgeApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesDairyEggsFridgeImageUri>? ImageUris { get; set; }
+            public ColesDairyEggsFridgePricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesDairyEggsFridgePricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesDairyEggsFridgeUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesDairyEggsFridgeUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesDairyEggsFridgeImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesDeliDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesDeliDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesDeliDomScraperService : IColesDeliDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/deli.json?slug=deli";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesDeliDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesDeliDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesDeliDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DELI_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached deli products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_DELI_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesDeliApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesDeliApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.DELI &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.DELI,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_deli_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesDeliApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesDeliApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,7 +377,7 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_DELI_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
@@ -389,19 +389,19 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_DELI_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 3000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_DELI_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesDeliApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesDeliPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesDeliPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesDeliSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesDeliSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesDeliApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesDeliApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesDeliImageUri>? ImageUris { get; set; }
+            public ColesDeliPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesDeliPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesDeliUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesDeliUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesDeliImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesDeliverMoreRangeDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesDeliverMoreRangeDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesDeliverMoreRangeDomScraperService : IColesDeliverMoreRangeDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/deliver-more-range.json?slug=deliver-more-range";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesDeliverMoreRangeDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesDeliverMoreRangeDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesDeliverMoreRangeDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DELIVER_MORE_RANGE_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached deliver more range products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_DELIVER_MORE_RANGE_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesDeliverMoreRangeApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesDeliverMoreRangeApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.DELIVER_MORE_RANGE &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.DELIVER_MORE_RANGE,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_deliver_more_range_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesDeliverMoreRangeApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesDeliverMoreRangeApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_DELIVER_MORE_RANGE_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_DELIVER_MORE_RANGE_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_DELIVER_MORE_RANGE_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesDeliverMoreRangeApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesDeliverMoreRangePageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesDeliverMoreRangePageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesDeliverMoreRangeSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesDeliverMoreRangeSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesDeliverMoreRangeApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesDeliverMoreRangeApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesDeliverMoreRangeImageUri>? ImageUris { get; set; }
+            public ColesDeliverMoreRangePricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesDeliverMoreRangePricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesDeliverMoreRangeUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesDeliverMoreRangeUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesDeliverMoreRangeImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesDietaryWorldFoodsDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesDietaryWorldFoodsDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesDietaryWorldFoodsDomScraperService : IColesDietaryWorldFoodsDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/dietary-world-foods.json?slug=dietary-world-foods";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesDietaryWorldFoodsDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesDietaryWorldFoodsDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesDietaryWorldFoodsDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DIETARY_WORLD_FOODS_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached dietary & world foods products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_DIETARY_WORLD_FOODS_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesDietaryWorldFoodsApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesDietaryWorldFoodsApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.DIETARY_WORLD_FOODS &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.DIETARY_WORLD_FOODS,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_dietary_world_foods_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesDietaryWorldFoodsApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesDietaryWorldFoodsApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_DIETARY_WORLD_FOODS_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_DIETARY_WORLD_FOODS_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_DIETARY_WORLD_FOODS_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesDietaryWorldFoodsApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesDietaryWorldFoodsPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesDietaryWorldFoodsPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesDietaryWorldFoodsSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesDietaryWorldFoodsSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesDietaryWorldFoodsApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesDietaryWorldFoodsApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesDietaryWorldFoodsImageUri>? ImageUris { get; set; }
+            public ColesDietaryWorldFoodsPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesDietaryWorldFoodsPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesDietaryWorldFoodsUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesDietaryWorldFoodsUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesDietaryWorldFoodsImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesDrinksDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesDrinksDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesDrinksDomScraperService : IColesDrinksDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/drinks.json?slug=drinks";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesDrinksDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesDrinksDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesDrinksDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DRINKS_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached drinks products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_DRINKS_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesDrinksApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesDrinksApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.DRINKS &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.DRINKS,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_drinks_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesDrinksApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesDrinksApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_DRINKS_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_DRINKS_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_DRINKS_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesDrinksApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesDrinksPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesDrinksPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesDrinksSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesDrinksSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesDrinksApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesDrinksApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesDrinksImageUri>? ImageUris { get; set; }
+            public ColesDrinksPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesDrinksPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesDrinksUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesDrinksUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesDrinksImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesFrozenDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesFrozenDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesFrozenDomScraperService : IColesFrozenDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/frozen.json?slug=frozen";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesFrozenDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesFrozenDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesFrozenDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_FROZEN_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached frozen products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_FROZEN_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesFrozenApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesFrozenApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.FROZEN &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.FROZEN,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_frozen_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesFrozenApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesFrozenApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_FROZEN_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_FROZEN_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_FROZEN_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesFrozenApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesFrozenPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesFrozenPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesFrozenSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesFrozenSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesFrozenApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesFrozenApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesFrozenImageUri>? ImageUris { get; set; }
+            public ColesFrozenPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesFrozenPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesFrozenUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesFrozenUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesFrozenImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesFruitVegetablesDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesFruitVegetablesDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesFruitVegetablesDomScraperService : IColesFruitVegetablesDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/fruit-vegetables.json?slug=fruit-vegetables";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesFruitVegetablesDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesFruitVegetablesDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesFruitVegetablesDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_FRUIT_VEGETABLES_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached fruit & vegetables products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_FRUIT_VEGETABLES_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesFruitVegetablesApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesFruitVegetablesApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.FRUIT_VEGETABLES &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.FRUIT_VEGETABLES,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_fruit_vegetables_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesFruitVegetablesApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesFruitVegetablesApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,7 +377,7 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_FRUIT_VEGETABLES_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
@@ -389,7 +389,7 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_FRUIT_VEGETABLES_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
@@ -401,7 +401,7 @@ namespace PriceCompareCore.Services
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_FRUIT_VEGETABLES_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesFruitVegetablesApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesFruitVegetablesPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesFruitVegetablesPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesFruitVegetablesSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesFruitVegetablesSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesFruitVegetablesApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesFruitVegetablesApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesFruitVegetablesImageUri>? ImageUris { get; set; }
+            public ColesFruitVegetablesPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesFruitVegetablesPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesFruitVegetablesUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesFruitVegetablesUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesFruitVegetablesImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesHealthBeautyDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesHealthBeautyDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesHealthBeautyDomScraperService : IColesHealthBeautyDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/health-beauty.json?slug=health-beauty";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesHealthBeautyDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesHealthBeautyDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesHealthBeautyDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_HEALTH_BEAUTY_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached health & beauty products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_HEALTH_BEAUTY_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesHealthBeautyApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesHealthBeautyApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.HEALTH_BEAUTY &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.HEALTH_BEAUTY,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_health_beauty_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesHealthBeautyApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesHealthBeautyApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_HEALTH_BEAUTY_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_HEALTH_BEAUTY_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_HEALTH_BEAUTY_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesHealthBeautyApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesHealthBeautyPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesHealthBeautyPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesHealthBeautySearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesHealthBeautySearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesHealthBeautyApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesHealthBeautyApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesHealthBeautyImageUri>? ImageUris { get; set; }
+            public ColesHealthBeautyPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesHealthBeautyPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesHealthBeautyUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesHealthBeautyUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesHealthBeautyImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesHomeGardenDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesHomeGardenDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesHomeGardenDomScraperService : IColesHomeGardenDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/home-garden.json?slug=home-garden";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesHomeGardenDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesHomeGardenDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesHomeGardenDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_HOME_GARDEN_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached home & garden products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_HOME_GARDEN_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesHomeGardenApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesHomeGardenApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.HOME_GARDEN &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.HOME_GARDEN,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_home_garden_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesHomeGardenApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesHomeGardenApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_HOME_GARDEN_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_HOME_GARDEN_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_HOME_GARDEN_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesHomeGardenApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesHomeGardenPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesHomeGardenPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesHomeGardenSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesHomeGardenSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesHomeGardenApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesHomeGardenApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesHomeGardenImageUri>? ImageUris { get; set; }
+            public ColesHomeGardenPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesHomeGardenPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesHomeGardenUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesHomeGardenUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesHomeGardenImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesLiquorlandDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesLiquorlandDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesLiquorlandDomScraperService : IColesLiquorlandDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/liquorland.json?slug=liquorland";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesLiquorlandDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesLiquorlandDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesLiquorlandDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_LIQUORLAND_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached liquorland products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_LIQUORLAND_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesLiquorlandApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesLiquorlandApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.LIQUORLAND &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.LIQUORLAND,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_liquorland_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesLiquorlandApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesLiquorlandApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_LIQUORLAND_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_LIQUORLAND_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_LIQUORLAND_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesLiquorlandApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesLiquorlandPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesLiquorlandPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesLiquorlandSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesLiquorlandSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesLiquorlandApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesLiquorlandApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesLiquorlandImageUri>? ImageUris { get; set; }
+            public ColesLiquorlandPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesLiquorlandPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesLiquorlandUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesLiquorlandUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesLiquorlandImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesMeatSeafoodDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesMeatSeafoodDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesMeatSeafoodDomScraperService : IColesMeatSeafoodDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/meat-seafood.json?slug=meat-seafood";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesMeatSeafoodDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesMeatSeafoodDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesMeatSeafoodDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_MEAT_SEAFOOD_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached meat & seafood products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_MEAT_SEAFOOD_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesMeatSeafoodApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesMeatSeafoodApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.MEAT_SEAFOOD &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.MEAT_SEAFOOD,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_meat_seafood_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesMeatSeafoodApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesMeatSeafoodApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,7 +377,7 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_MEAT_SEAFOOD_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
@@ -389,7 +389,7 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_MEAT_SEAFOOD_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
@@ -401,7 +401,7 @@ namespace PriceCompareCore.Services
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_MEAT_SEAFOOD_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesMeatSeafoodApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesMeatSeafoodPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesMeatSeafoodPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesMeatSeafoodSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesMeatSeafoodSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesMeatSeafoodApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesMeatSeafoodApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesMeatSeafoodImageUri>? ImageUris { get; set; }
+            public ColesMeatSeafoodPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesMeatSeafoodPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesMeatSeafoodUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesMeatSeafoodUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesMeatSeafoodImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesPantryDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesPantryDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesPantryDomScraperService : IColesPantryDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/pantry.json?slug=pantry";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesPantryDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesPantryDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesPantryDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_PANTRY_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached pantry products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_PANTRY_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesPantryApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesPantryApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.PANTRY &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.PANTRY,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_pantry_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesPantryApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesPantryApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_PANTRY_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_PANTRY_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_PANTRY_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesPantryApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesPantryPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesPantryPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesPantrySearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesPantrySearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesPantryApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesPantryApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesPantryImageUri>? ImageUris { get; set; }
+            public ColesPantryPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesPantryPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesPantryUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesPantryUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesPantryImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareCore/Services/ColesPetDomScraperService.cs
+++ b/src/PriceCompareCore/Services/ColesPetDomScraperService.cs
@@ -18,9 +18,9 @@ using PriceCompareData.Entities.History;
 
 namespace PriceCompareCore.Services
 {
-    public class ColesDownDomScraperService : IColesDownDomScraperService
+    public class ColesPetDomScraperService : IColesPetDomScraperService
     {
-        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/down-down.json?slug=down-down";
+        private const string DefaultDataUrl = WebInfo.COLES_NEXT_DATA_BASE + "/en/browse/pet.json?slug=pet";
         private const string BaseUrl = "https://www.coles.com.au";
         private const string ImageBase = "https://cdn.productimages.coles.com.au/productimages";
         private const string DefaultUa =
@@ -28,7 +28,7 @@ namespace PriceCompareCore.Services
             "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
         private readonly HttpClient _httpClient;
-        private readonly ILogger<ColesDownDomScraperService> _logger;
+        private readonly ILogger<ColesPetDomScraperService> _logger;
         private readonly IDistributedCache _cache;
         private readonly AppDbContext _dbContext;
         private readonly IIngestionService _ingestion;
@@ -36,9 +36,9 @@ namespace PriceCompareCore.Services
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        public ColesDownDomScraperService(
+        public ColesPetDomScraperService(
             HttpClient httpClient,
-            ILogger<ColesDownDomScraperService> logger,
+            ILogger<ColesPetDomScraperService> logger,
             IDistributedCache cache,
             AppDbContext dbContext,
             IIngestionService ingestion,
@@ -61,10 +61,10 @@ namespace PriceCompareCore.Services
             if (limit <= 0) limit = hardCap;
             if (limit > hardCap) limit = hardCap;
 
-            // var cached = await _cache.GetStringAsync(CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS, ct);
+            // var cached = await _cache.GetStringAsync(CacheKey.COLES_PET_DOM_PRODUCTS, ct);
             // if (!string.IsNullOrWhiteSpace(cached))
             // {
-            //     _logger.LogInformation("Coles JSON: returning cached down-down products.");
+            //     _logger.LogInformation("Coles JSON: returning cached pet products.");
             //     var cachedItems = JsonSerializer.Deserialize<List<ColesDownProduct>>(cached, JsonOptions) ?? new();
             //     return cachedItems.Take(limit).ToList();
             // }
@@ -98,7 +98,7 @@ namespace PriceCompareCore.Services
             _logger.LogInformation("Coles JSON: extracted {Count} products.", all.Count);
 
             await _cache.SetStringAsync(
-                CacheKey.COLES_DOWNDOWN_DOM_PRODUCTS,
+                CacheKey.COLES_PET_DOM_PRODUCTS,
                 JsonSerializer.Serialize(all, JsonOptions),
                 new DistributedCacheEntryOptions
                 {
@@ -138,10 +138,10 @@ namespace PriceCompareCore.Services
             HashSet<string> seenNames)
         {
             var results = new List<ColesDownProduct>();
-            ColesDownApiResponse? dto;
+            ColesPetApiResponse? dto;
             try
             {
-                dto = JsonSerializer.Deserialize<ColesDownApiResponse>(json, JsonOptions);
+                dto = JsonSerializer.Deserialize<ColesPetApiResponse>(json, JsonOptions);
             }
             catch
             {
@@ -234,7 +234,7 @@ namespace PriceCompareCore.Services
                 var exists = _dbContext.PriceHistory.Any(ph =>
                     ph.Name == product.Name &&
                     ph.ShopType == ShopType.COLES &&
-                    ph.OfferType == OfferType.DOWN_DOWN &&
+                    ph.OfferType == OfferType.PET &&
                     ph.ScrapedAt >= today &&
                     ph.ScrapedAt < today.AddDays(1));
 
@@ -244,7 +244,7 @@ namespace PriceCompareCore.Services
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     CurrentPrice = product.CurrentPrice,
                     ScrapedAt = scrapedAt,
-                    OfferType = OfferType.DOWN_DOWN,
+                    OfferType = OfferType.PET,
                     ShopType = ShopType.COLES
                 };
 
@@ -261,7 +261,7 @@ namespace PriceCompareCore.Services
             var productRows = _ingestion.MapColesDownProducts(products);
             await _export.ExportAsync(
                 new ScrapeExportRequest(
-                    "coles_down_json",
+                    "coles_pet_json",
                     scrapedAt,
                     priceHistoryRows,
                     productRows),
@@ -296,7 +296,7 @@ namespace PriceCompareCore.Services
             return Regex.IsMatch(url, pattern, RegexOptions.IgnoreCase);
         }
 
-        private static string BuildDisplayName(ColesDownApiProduct item)
+        private static string BuildDisplayName(ColesPetApiProduct item)
         {
             var parts = new List<string>();
             if (!string.IsNullOrWhiteSpace(item.Brand))
@@ -321,7 +321,7 @@ namespace PriceCompareCore.Services
             return NormalizeWhitespace(name);
         }
 
-        private static string BuildProductUrl(ColesDownApiProduct item, string displayName, int id)
+        private static string BuildProductUrl(ColesPetApiProduct item, string displayName, int id)
         {
             if (id <= 0)
             {
@@ -377,31 +377,31 @@ namespace PriceCompareCore.Services
 
         private static int GetMaxPages()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_PAGES");
+            var raw = Environment.GetEnvironmentVariable("COLES_PET_MAX_PAGES");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_PAGES");
-            return int.TryParse(raw, out v) && v > 0 ? v : 50;
+            return int.TryParse(raw, out v) && v > 0 ? v : 150;
         }
 
         private static int GetMaxItems()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_MAX_ITEMS");
+            var raw = Environment.GetEnvironmentVariable("COLES_PET_MAX_ITEMS");
             if (int.TryParse(raw, out var v) && v > 0)
             {
                 return v;
             }
 
             raw = Environment.GetEnvironmentVariable("COLES_DOM_MAX_ITEMS");
-            return int.TryParse(raw, out v) && v > 0 ? v : 1000;
+            return int.TryParse(raw, out v) && v > 0 ? v : 7000;
         }
 
         private static string GetDataUrl()
         {
-            var raw = Environment.GetEnvironmentVariable("COLES_DOWNDOWN_DATA_URL");
+            var raw = Environment.GetEnvironmentVariable("COLES_PET_DATA_URL");
             return string.IsNullOrWhiteSpace(raw) ? DefaultDataUrl : raw.Trim();
         }
 
@@ -411,22 +411,22 @@ namespace PriceCompareCore.Services
             return string.IsNullOrWhiteSpace(raw) ? DefaultUa : raw.Trim();
         }
 
-        private class ColesDownApiResponse
+        private class ColesPetApiResponse
         {
-            public ColesDownPageProps? PageProps { get; set; }
+            public ColesPetPageProps? PageProps { get; set; }
         }
 
-        private class ColesDownPageProps
+        private class ColesPetPageProps
         {
-            public ColesDownSearchResults? SearchResults { get; set; }
+            public ColesPetSearchResults? SearchResults { get; set; }
         }
 
-        private class ColesDownSearchResults
+        private class ColesPetSearchResults
         {
-            public List<ColesDownApiProduct> Results { get; set; } = new();
+            public List<ColesPetApiProduct> Results { get; set; } = new();
         }
 
-        private class ColesDownApiProduct
+        private class ColesPetApiProduct
         {
             public string? _type { get; set; }
             public int Id { get; set; }
@@ -439,23 +439,23 @@ namespace PriceCompareCore.Services
             public string? Size { get; set; }
             public bool Availability { get; set; }
             public string? AvailabilityType { get; set; }
-            public List<ColesDownImageUri>? ImageUris { get; set; }
-            public ColesDownPricing? Pricing { get; set; }
+            public List<ColesPetImageUri>? ImageUris { get; set; }
+            public ColesPetPricing? Pricing { get; set; }
         }
 
-        private class ColesDownPricing
+        private class ColesPetPricing
         {
             public decimal? Now { get; set; }
             public decimal? Was { get; set; }
             public decimal? SaveAmount { get; set; }
             public string? PriceDescription { get; set; }
-            public ColesDownUnit? Unit { get; set; }
+            public ColesPetUnit? Unit { get; set; }
             public string? Comparable { get; set; }
             public string? PromotionType { get; set; }
             public bool? OnlineSpecial { get; set; }
         }
 
-        private class ColesDownUnit
+        private class ColesPetUnit
         {
             public decimal? Quantity { get; set; }
             public decimal? OfMeasureQuantity { get; set; }
@@ -466,7 +466,7 @@ namespace PriceCompareCore.Services
             public bool? IsIncremental { get; set; }
         }
 
-        private class ColesDownImageUri
+        private class ColesPetImageUri
         {
             public string? AltText { get; set; }
             public string? Type { get; set; }

--- a/src/PriceCompareData/Common/CacheKey.cs
+++ b/src/PriceCompareData/Common/CacheKey.cs
@@ -9,6 +9,25 @@ namespace PriceCompareData.Entities.Common
     {
         public const string COLES_DOWNDOWN_PRODUCTS = "ColesDownDownProducts";
         public const string COLES_DOWNDOWN_DOM_PRODUCTS = "ColesDownDownDomProducts";
+        public const string COLES_MEAT_SEAFOOD_DOM_PRODUCTS = "ColesMeatSeafoodDomProducts";
+        public const string COLES_FRUIT_VEGETABLES_DOM_PRODUCTS = "ColesFruitVegetablesDomProducts";
+        public const string COLES_DAIRY_EGGS_FRIDGE_DOM_PRODUCTS = "ColesDairyEggsFridgeDomProducts";
+        public const string COLES_BAKERY_DOM_PRODUCTS = "ColesBakeryDomProducts";
+        public const string COLES_DELI_DOM_PRODUCTS = "ColesDeliDomProducts";
+        public const string COLES_PANTRY_DOM_PRODUCTS = "ColesPantryDomProducts";
+        public const string COLES_DIETARY_WORLD_FOODS_DOM_PRODUCTS = "ColesDietaryWorldFoodsDomProducts";
+        public const string COLES_CHIPS_CHOCOLATES_SNACKS_DOM_PRODUCTS = "ColesChipsChocolatesSnacksDomProducts";
+        public const string COLES_DRINKS_DOM_PRODUCTS = "ColesDrinksDomProducts";
+        public const string COLES_LIQUORLAND_DOM_PRODUCTS = "ColesLiquorlandDomProducts";
+        public const string COLES_FROZEN_DOM_PRODUCTS = "ColesFrozenDomProducts";
+        public const string COLES_CLEANING_LAUNDRY_DOM_PRODUCTS = "ColesCleaningLaundryDomProducts";
+        public const string COLES_HEALTH_BEAUTY_DOM_PRODUCTS = "ColesHealthBeautyDomProducts";
+        public const string COLES_BABY_DOM_PRODUCTS = "ColesBabyDomProducts";
+        public const string COLES_PET_DOM_PRODUCTS = "ColesPetDomProducts";
+        public const string COLES_HOME_GARDEN_DOM_PRODUCTS = "ColesHomeGardenDomProducts";
+        public const string COLES_BIG_PACK_VALUE_DOM_PRODUCTS = "ColesBigPackValueDomProducts";
+        public const string COLES_BONUS_CREDIT_PRODUCTS_DOM_PRODUCTS = "ColesBonusCreditProductsDomProducts";
+        public const string COLES_DELIVER_MORE_RANGE_DOM_PRODUCTS = "ColesDeliverMoreRangeDomProducts";
         public const string COLES_ON_SPECIAL_PRODUCTS = "ColesOnSpecialProducts";
         public const string BUILD_ID = "BuildId";
         public const string WOOLWORTHS_ON_SPECIAL_PRODUCTS = "WoolworthsOnSpecialProducts";

--- a/src/PriceCompareData/Common/OfferType.cs
+++ b/src/PriceCompareData/Common/OfferType.cs
@@ -12,5 +12,24 @@ namespace PriceCompareData.Common
         public const int LOWER_SHELF = 2;
         public const int EVERYDAY_LOW_PRICE = 3;
         public const int HALF_PRICE = 4;
+        public const int MEAT_SEAFOOD = 5;
+        public const int FRUIT_VEGETABLES = 6;
+        public const int DAIRY_EGGS_FRIDGE = 7;
+        public const int BAKERY = 8;
+        public const int DELI = 9;
+        public const int PANTRY = 10;
+        public const int DIETARY_WORLD_FOODS = 11;
+        public const int CHIPS_CHOCOLATES_SNACKS = 12;
+        public const int DRINKS = 13;
+        public const int LIQUORLAND = 14;
+        public const int FROZEN = 15;
+        public const int CLEANING_LAUNDRY = 16;
+        public const int HEALTH_BEAUTY = 17;
+        public const int BABY = 18;
+        public const int PET = 19;
+        public const int HOME_GARDEN = 20;
+        public const int BIG_PACK_VALUE = 21;
+        public const int BONUS_CREDIT_PRODUCTS = 22;
+        public const int DELIVER_MORE_RANGE = 23;
     }
 }

--- a/src/PriceCompareData/Common/WebInfo.cs
+++ b/src/PriceCompareData/Common/WebInfo.cs
@@ -8,5 +8,8 @@ namespace PriceCompareData.Entities.Common
     public class WebInfo
     {
         public const string COLES_BASE_URL = "https://www.coles.com.au";
+        // Next.js build id used in Coles _next/data URLs. Update this when Coles deploys.
+        public const string COLES_NEXT_BUILD_ID = "20260127.7-95792a7a1587133fb3156d8da8fe0d2cb20a640a";
+        public const string COLES_NEXT_DATA_BASE = COLES_BASE_URL + "/_next/data/" + COLES_NEXT_BUILD_ID;
     }
 }

--- a/src/PriceCompareWeb/Controllers/ScrapingController.cs
+++ b/src/PriceCompareWeb/Controllers/ScrapingController.cs
@@ -16,6 +16,25 @@ namespace PriceCompareWeb.Controllers
         private readonly IColesDownScraperService _scraperService;
         private readonly IColesSpecialScraperService _specialScraperService;
         private readonly IColesDownDomScraperService _colesDownDomService;
+        private readonly IColesMeatSeafoodDomScraperService _colesMeatSeafoodDomService;
+        private readonly IColesFruitVegetablesDomScraperService _colesFruitVegetablesDomService;
+        private readonly IColesDairyEggsFridgeDomScraperService _colesDairyEggsFridgeDomService;
+        private readonly IColesBakeryDomScraperService _colesBakeryDomService;
+        private readonly IColesDeliDomScraperService _colesDeliDomService;
+        private readonly IColesPantryDomScraperService _colesPantryDomService;
+        private readonly IColesDietaryWorldFoodsDomScraperService _colesDietaryWorldFoodsDomService;
+        private readonly IColesChipsChocolatesSnacksDomScraperService _colesChipsChocolatesSnacksDomService;
+        private readonly IColesDrinksDomScraperService _colesDrinksDomService;
+        private readonly IColesLiquorlandDomScraperService _colesLiquorlandDomService;
+        private readonly IColesFrozenDomScraperService _colesFrozenDomService;
+        private readonly IColesCleaningLaundryDomScraperService _colesCleaningLaundryDomService;
+        private readonly IColesHealthBeautyDomScraperService _colesHealthBeautyDomService;
+        private readonly IColesBabyDomScraperService _colesBabyDomService;
+        private readonly IColesPetDomScraperService _colesPetDomService;
+        private readonly IColesHomeGardenDomScraperService _colesHomeGardenDomService;
+        private readonly IColesBigPackValueDomScraperService _colesBigPackValueDomService;
+        private readonly IColesBonusCreditProductsDomScraperService _colesBonusCreditProductsDomService;
+        private readonly IColesDeliverMoreRangeDomScraperService _colesDeliverMoreRangeDomService;
         private readonly ILogger<ScrapingController> _logger;
         private readonly IWoolworthsSpecialScraperService _wscraperService;
         private readonly IWoolworthsLowerShelfDomScraperService _wwsLowerShelfDomService;
@@ -26,6 +45,25 @@ namespace PriceCompareWeb.Controllers
         ILogger<ScrapingController> logger,
         IColesSpecialScraperService specialScraperService,
         IColesDownDomScraperService colesDownDomService,
+        IColesMeatSeafoodDomScraperService colesMeatSeafoodDomService,
+        IColesFruitVegetablesDomScraperService colesFruitVegetablesDomService,
+        IColesDairyEggsFridgeDomScraperService colesDairyEggsFridgeDomService,
+        IColesBakeryDomScraperService colesBakeryDomService,
+        IColesDeliDomScraperService colesDeliDomService,
+        IColesPantryDomScraperService colesPantryDomService,
+        IColesDietaryWorldFoodsDomScraperService colesDietaryWorldFoodsDomService,
+        IColesChipsChocolatesSnacksDomScraperService colesChipsChocolatesSnacksDomService,
+        IColesDrinksDomScraperService colesDrinksDomService,
+        IColesLiquorlandDomScraperService colesLiquorlandDomService,
+        IColesFrozenDomScraperService colesFrozenDomService,
+        IColesCleaningLaundryDomScraperService colesCleaningLaundryDomService,
+        IColesHealthBeautyDomScraperService colesHealthBeautyDomService,
+        IColesBabyDomScraperService colesBabyDomService,
+        IColesPetDomScraperService colesPetDomService,
+        IColesHomeGardenDomScraperService colesHomeGardenDomService,
+        IColesBigPackValueDomScraperService colesBigPackValueDomService,
+        IColesBonusCreditProductsDomScraperService colesBonusCreditProductsDomService,
+        IColesDeliverMoreRangeDomScraperService colesDeliverMoreRangeDomService,
         IWoolworthsSpecialScraperService wscraperService,
         IWoolworthsLowerShelfDomScraperService wwsLowerShelfDomService,
         IWoolworthsEverydayLowPriceDomScraperService wwsEverydayLowPriceDomService,
@@ -35,6 +73,25 @@ namespace PriceCompareWeb.Controllers
             _logger = logger;
             _specialScraperService = specialScraperService;
             _colesDownDomService = colesDownDomService;
+            _colesMeatSeafoodDomService = colesMeatSeafoodDomService;
+            _colesFruitVegetablesDomService = colesFruitVegetablesDomService;
+            _colesDairyEggsFridgeDomService = colesDairyEggsFridgeDomService;
+            _colesBakeryDomService = colesBakeryDomService;
+            _colesDeliDomService = colesDeliDomService;
+            _colesPantryDomService = colesPantryDomService;
+            _colesDietaryWorldFoodsDomService = colesDietaryWorldFoodsDomService;
+            _colesChipsChocolatesSnacksDomService = colesChipsChocolatesSnacksDomService;
+            _colesDrinksDomService = colesDrinksDomService;
+            _colesLiquorlandDomService = colesLiquorlandDomService;
+            _colesFrozenDomService = colesFrozenDomService;
+            _colesCleaningLaundryDomService = colesCleaningLaundryDomService;
+            _colesHealthBeautyDomService = colesHealthBeautyDomService;
+            _colesBabyDomService = colesBabyDomService;
+            _colesPetDomService = colesPetDomService;
+            _colesHomeGardenDomService = colesHomeGardenDomService;
+            _colesBigPackValueDomService = colesBigPackValueDomService;
+            _colesBonusCreditProductsDomService = colesBonusCreditProductsDomService;
+            _colesDeliverMoreRangeDomService = colesDeliverMoreRangeDomService;
             _wscraperService = wscraperService;
             _wwsLowerShelfDomService = wwsLowerShelfDomService;
             _wwsEverydayLowPriceDomService = wwsEverydayLowPriceDomService;
@@ -83,7 +140,369 @@ namespace PriceCompareWeb.Controllers
             }
         }
 
+        [HttpGet("coles/meat-seafood/dom")]
+        public async Task<IActionResult> GetMeatSeafoodDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesMeatSeafoodDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles meat & seafood DOM products");
+                return StatusCode(500, "Failed to get Coles meat & seafood DOM products");
+            }
+        }
+
+        [HttpGet("coles/fruit-vegetables/dom")]
+        public async Task<IActionResult> GetFruitVegetablesDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesFruitVegetablesDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles fruit & vegetables DOM products");
+                return StatusCode(500, "Failed to get Coles fruit & vegetables DOM products");
+            }
+        }
+
+        [HttpGet("coles/dairy-eggs-fridge/dom")]
+        public async Task<IActionResult> GetDairyEggsFridgeDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesDairyEggsFridgeDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles dairy, eggs & fridge DOM products");
+                return StatusCode(500, "Failed to get Coles dairy, eggs & fridge DOM products");
+            }
+        }
+
+        [HttpGet("coles/bakery/dom")]
+        public async Task<IActionResult> GetBakeryDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesBakeryDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles bakery DOM products");
+                return StatusCode(500, "Failed to get Coles bakery DOM products");
+            }
+        }
+
+        [HttpGet("coles/deli/dom")]
+        public async Task<IActionResult> GetDeliDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesDeliDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles deli DOM products");
+                return StatusCode(500, "Failed to get Coles deli DOM products");
+            }
+        }
+
+        [HttpGet("coles/pantry/dom")]
+        public async Task<IActionResult> GetPantryDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesPantryDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles pantry DOM products");
+                return StatusCode(500, "Failed to get Coles pantry DOM products");
+            }
+        }
+
+        [HttpGet("coles/dietary-world-foods/dom")]
+        public async Task<IActionResult> GetDietaryWorldFoodsDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesDietaryWorldFoodsDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles dietary & world foods DOM products");
+                return StatusCode(500, "Failed to get Coles dietary & world foods DOM products");
+            }
+        }
+
+        [HttpGet("coles/chips-chocolates-snacks/dom")]
+        public async Task<IActionResult> GetChipsChocolatesSnacksDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesChipsChocolatesSnacksDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles chips, chocolates & snacks DOM products");
+                return StatusCode(500, "Failed to get Coles chips, chocolates & snacks DOM products");
+            }
+        }
+
+        [HttpGet("coles/drinks/dom")]
+        public async Task<IActionResult> GetDrinksDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesDrinksDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles drinks DOM products");
+                return StatusCode(500, "Failed to get Coles drinks DOM products");
+            }
+        }
+
+        [HttpGet("coles/liquorland/dom")]
+        public async Task<IActionResult> GetLiquorlandDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesLiquorlandDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles liquorland DOM products");
+                return StatusCode(500, "Failed to get Coles liquorland DOM products");
+            }
+        }
+
+        [HttpGet("coles/frozen/dom")]
+        public async Task<IActionResult> GetFrozenDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesFrozenDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles frozen DOM products");
+                return StatusCode(500, "Failed to get Coles frozen DOM products");
+            }
+        }
+
+        [HttpGet("coles/cleaning-laundry/dom")]
+        public async Task<IActionResult> GetCleaningLaundryDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesCleaningLaundryDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles cleaning & laundry DOM products");
+                return StatusCode(500, "Failed to get Coles cleaning & laundry DOM products");
+            }
+        }
+
+        [HttpGet("coles/health-beauty/dom")]
+        public async Task<IActionResult> GetHealthBeautyDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesHealthBeautyDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles health & beauty DOM products");
+                return StatusCode(500, "Failed to get Coles health & beauty DOM products");
+            }
+        }
+
+        [HttpGet("coles/baby/dom")]
+        public async Task<IActionResult> GetBabyDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesBabyDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles baby DOM products");
+                return StatusCode(500, "Failed to get Coles baby DOM products");
+            }
+        }
+
+        [HttpGet("coles/pet/dom")]
+        public async Task<IActionResult> GetPetDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesPetDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles pet DOM products");
+                return StatusCode(500, "Failed to get Coles pet DOM products");
+            }
+        }
+
+        [HttpGet("coles/home-garden/dom")]
+        public async Task<IActionResult> GetHomeGardenDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesHomeGardenDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles home & garden DOM products");
+                return StatusCode(500, "Failed to get Coles home & garden DOM products");
+            }
+        }
+
+        [HttpGet("coles/big-pack-value/dom")]
+        public async Task<IActionResult> GetBigPackValueDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesBigPackValueDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles big pack value DOM products");
+                return StatusCode(500, "Failed to get Coles big pack value DOM products");
+            }
+        }
+
+        [HttpGet("coles/bonus-credit-products/dom")]
+        public async Task<IActionResult> GetBonusCreditProductsDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesBonusCreditProductsDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles bonus credit products DOM products");
+                return StatusCode(500, "Failed to get Coles bonus credit products DOM products");
+            }
+        }
+
+        [HttpGet("coles/deliver-more-range/dom")]
+        public async Task<IActionResult> GetDeliverMoreRangeDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _colesDeliverMoreRangeDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new
+                {
+                    Count = products.Count,
+                    Products = products
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Coles deliver more range DOM products");
+                return StatusCode(500, "Failed to get Coles deliver more range DOM products");
+            }
+        }
+
         [HttpGet("coles/on-special/all")]
+        [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<IActionResult> GetOnSpecialProducts([FromQuery] ColesSpecialProductRequest request, [FromQuery] int page = 1, [FromQuery] int pageSize = 20)
         {
             try

--- a/src/PriceCompareWeb/Program.cs
+++ b/src/PriceCompareWeb/Program.cs
@@ -122,6 +122,15 @@ if (enableQuartzJobs)
     {
         q.UseMicrosoftDependencyInjectionJobFactory();
         q.AddJobListener<LoggingJobListener>();
+        TimeZoneInfo aedtTz;
+        try
+        {
+            aedtTz = TimeZoneInfo.FindSystemTimeZoneById("AUS Eastern Standard Time");
+        }
+        catch
+        {
+            aedtTz = TimeZoneInfo.FindSystemTimeZoneById("Australia/Sydney");
+        }
 
         // scrape data - coles down down
         var jobKey = new JobKey("ColesRefreshJob");
@@ -163,6 +172,98 @@ if (enableQuartzJobs)
             .WithIdentity("WwsHalfPriceDomJob-trigger")
             .WithCronSchedule("0 0 4 ? * WED"));
 
+        // temp sequential scrape - coles DOM categories (every 15 minutes from 19:10)
+        var jobKeyColesDietaryWorldFoods = new JobKey("ColesDietaryWorldFoodsDomJob");
+        q.AddJob<ColesDietaryWorldFoodsDomJob>(opts => opts.WithIdentity(jobKeyColesDietaryWorldFoods));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesDietaryWorldFoods)
+            .WithIdentity("ColesDietaryWorldFoodsDomJob-trigger")
+            .WithCronSchedule("0 45 19 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesChipsChocolatesSnacks = new JobKey("ColesChipsChocolatesSnacksDomJob");
+        q.AddJob<ColesChipsChocolatesSnacksDomJob>(opts => opts.WithIdentity(jobKeyColesChipsChocolatesSnacks));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesChipsChocolatesSnacks)
+            .WithIdentity("ColesChipsChocolatesSnacksDomJob-trigger")
+            .WithCronSchedule("0 15 20 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesDrinks = new JobKey("ColesDrinksDomJob");
+        q.AddJob<ColesDrinksDomJob>(opts => opts.WithIdentity(jobKeyColesDrinks));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesDrinks)
+            .WithIdentity("ColesDrinksDomJob-trigger")
+            .WithCronSchedule("0 45 20 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesLiquorland = new JobKey("ColesLiquorlandDomJob");
+        q.AddJob<ColesLiquorlandDomJob>(opts => opts.WithIdentity(jobKeyColesLiquorland));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesLiquorland)
+            .WithIdentity("ColesLiquorlandDomJob-trigger")
+            .WithCronSchedule("0 15 21 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesFrozen = new JobKey("ColesFrozenDomJob");
+        q.AddJob<ColesFrozenDomJob>(opts => opts.WithIdentity(jobKeyColesFrozen));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesFrozen)
+            .WithIdentity("ColesFrozenDomJob-trigger")
+            .WithCronSchedule("0 45 21 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesCleaningLaundry = new JobKey("ColesCleaningLaundryDomJob");
+        q.AddJob<ColesCleaningLaundryDomJob>(opts => opts.WithIdentity(jobKeyColesCleaningLaundry));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesCleaningLaundry)
+            .WithIdentity("ColesCleaningLaundryDomJob-trigger")
+            .WithCronSchedule("0 15 22 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesHealthBeauty = new JobKey("ColesHealthBeautyDomJob");
+        q.AddJob<ColesHealthBeautyDomJob>(opts => opts.WithIdentity(jobKeyColesHealthBeauty));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesHealthBeauty)
+            .WithIdentity("ColesHealthBeautyDomJob-trigger")
+            .WithCronSchedule("0 45 22 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesBaby = new JobKey("ColesBabyDomJob");
+        q.AddJob<ColesBabyDomJob>(opts => opts.WithIdentity(jobKeyColesBaby));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesBaby)
+            .WithIdentity("ColesBabyDomJob-trigger")
+            .WithCronSchedule("0 15 23 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesPet = new JobKey("ColesPetDomJob");
+        q.AddJob<ColesPetDomJob>(opts => opts.WithIdentity(jobKeyColesPet));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesPet)
+            .WithIdentity("ColesPetDomJob-trigger")
+            .WithCronSchedule("0 45 23 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesHomeGarden = new JobKey("ColesHomeGardenDomJob");
+        q.AddJob<ColesHomeGardenDomJob>(opts => opts.WithIdentity(jobKeyColesHomeGarden));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesHomeGarden)
+            .WithIdentity("ColesHomeGardenDomJob-trigger")
+            .WithCronSchedule("0 15 0 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesBigPackValue = new JobKey("ColesBigPackValueDomJob");
+        q.AddJob<ColesBigPackValueDomJob>(opts => opts.WithIdentity(jobKeyColesBigPackValue));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesBigPackValue)
+            .WithIdentity("ColesBigPackValueDomJob-trigger")
+            .WithCronSchedule("0 45 0 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesBonusCreditProducts = new JobKey("ColesBonusCreditProductsDomJob");
+        q.AddJob<ColesBonusCreditProductsDomJob>(opts => opts.WithIdentity(jobKeyColesBonusCreditProducts));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesBonusCreditProducts)
+            .WithIdentity("ColesBonusCreditProductsDomJob-trigger")
+            .WithCronSchedule("0 15 1 ? * *", x => x.InTimeZone(aedtTz)));
+
+        var jobKeyColesDeliverMoreRange = new JobKey("ColesDeliverMoreRangeDomJob");
+        q.AddJob<ColesDeliverMoreRangeDomJob>(opts => opts.WithIdentity(jobKeyColesDeliverMoreRange));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyColesDeliverMoreRange)
+            .WithIdentity("ColesDeliverMoreRangeDomJob-trigger")
+            .WithCronSchedule("0 45 1 ? * *", x => x.InTimeZone(aedtTz)));
+
         // delete data
         var cleanJobKey = new JobKey("CleanPriceHistoryJob");
         q.AddJob<CleanPriceHistoryJob>(opts => opts.WithIdentity(cleanJobKey));
@@ -196,6 +297,25 @@ builder.Services.AddHttpClient<IColesDownScraperService, ColesDownScraperService
 
 builder.Services.AddScoped<IColesSpecialScraperService, ColesSpecialScraperService>();
 builder.Services.AddHttpClient<IColesDownDomScraperService, ColesDownDomScraperService>();
+builder.Services.AddHttpClient<IColesMeatSeafoodDomScraperService, ColesMeatSeafoodDomScraperService>();
+builder.Services.AddHttpClient<IColesFruitVegetablesDomScraperService, ColesFruitVegetablesDomScraperService>();
+builder.Services.AddHttpClient<IColesDairyEggsFridgeDomScraperService, ColesDairyEggsFridgeDomScraperService>();
+builder.Services.AddHttpClient<IColesBakeryDomScraperService, ColesBakeryDomScraperService>();
+builder.Services.AddHttpClient<IColesDeliDomScraperService, ColesDeliDomScraperService>();
+builder.Services.AddHttpClient<IColesPantryDomScraperService, ColesPantryDomScraperService>();
+builder.Services.AddHttpClient<IColesDietaryWorldFoodsDomScraperService, ColesDietaryWorldFoodsDomScraperService>();
+builder.Services.AddHttpClient<IColesChipsChocolatesSnacksDomScraperService, ColesChipsChocolatesSnacksDomScraperService>();
+builder.Services.AddHttpClient<IColesDrinksDomScraperService, ColesDrinksDomScraperService>();
+builder.Services.AddHttpClient<IColesLiquorlandDomScraperService, ColesLiquorlandDomScraperService>();
+builder.Services.AddHttpClient<IColesFrozenDomScraperService, ColesFrozenDomScraperService>();
+builder.Services.AddHttpClient<IColesCleaningLaundryDomScraperService, ColesCleaningLaundryDomScraperService>();
+builder.Services.AddHttpClient<IColesHealthBeautyDomScraperService, ColesHealthBeautyDomScraperService>();
+builder.Services.AddHttpClient<IColesBabyDomScraperService, ColesBabyDomScraperService>();
+builder.Services.AddHttpClient<IColesPetDomScraperService, ColesPetDomScraperService>();
+builder.Services.AddHttpClient<IColesHomeGardenDomScraperService, ColesHomeGardenDomScraperService>();
+builder.Services.AddHttpClient<IColesBigPackValueDomScraperService, ColesBigPackValueDomScraperService>();
+builder.Services.AddHttpClient<IColesBonusCreditProductsDomScraperService, ColesBonusCreditProductsDomScraperService>();
+builder.Services.AddHttpClient<IColesDeliverMoreRangeDomScraperService, ColesDeliverMoreRangeDomScraperService>();
 
 builder.Services.AddScoped<IWoolworthsSpecialScraperService, WoolworthsSpecialScraperService>();
 builder.Services.AddScoped<IWoolworthsLowerShelfDomScraperService, WoolworthsLowerShelfDomScraperService>();


### PR DESCRIPTION
- Add Coles DOM scrapers and endpoints for multiple categories
- Register new services and routes
- Add Quartz jobs/triggers in AEDT, 30-min increments from 19:45
- Enforce sequential execution via shared Coles job lock
- Centralize Coles Next.js build ID into a single constant

BTS-101