### PR TITLE
BTS-104: Update pricehistory rows during CSV SQL import

### DIFF
--- a/src/PriceCompareWeb/Services/ScrapeImportSqlService.cs
+++ b/src/PriceCompareWeb/Services/ScrapeImportSqlService.cs
@@ -268,9 +268,8 @@ namespace PriceCompareWeb.Services
 
         private static async Task WritePriceHistoryBatchAsync(StreamWriter writer, IReadOnlyList<PriceHistoryRow> batch, CancellationToken ct)
         {
-            await writer.WriteLineAsync("INSERT INTO pricehistory (name, currentprice, imageurl, scrapedat, offertype, shoptype, promotext)");
-            await writer.WriteLineAsync("SELECT v.name, v.currentprice, v.imageurl, v.scrapedat, v.offertype, v.shoptype, v.promotext");
-            await writer.WriteLineAsync("FROM (VALUES");
+            await writer.WriteLineAsync("WITH v(name, currentprice, imageurl, scrapedat, offertype, shoptype, promotext) AS (");
+            await writer.WriteLineAsync("  VALUES");
 
             for (var i = 0; i < batch.Count; i++)
             {
@@ -280,7 +279,21 @@ namespace PriceCompareWeb.Services
                 await writer.WriteLineAsync(line);
             }
 
-            await writer.WriteLineAsync(") AS v(name, currentprice, imageurl, scrapedat, offertype, shoptype, promotext)");
+            await writer.WriteLineAsync(")");
+            await writer.WriteLineAsync("UPDATE pricehistory ph");
+            await writer.WriteLineAsync("SET currentprice = v.currentprice,");
+            await writer.WriteLineAsync("    imageurl = v.imageurl,");
+            await writer.WriteLineAsync("    scrapedat = v.scrapedat,");
+            await writer.WriteLineAsync("    promotext = v.promotext");
+            await writer.WriteLineAsync("FROM v");
+            await writer.WriteLineAsync("WHERE ph.name = v.name");
+            await writer.WriteLineAsync("  AND ph.shoptype IS NOT DISTINCT FROM v.shoptype");
+            await writer.WriteLineAsync("  AND ph.offertype IS NOT DISTINCT FROM v.offertype");
+            await writer.WriteLineAsync("  AND ph.scrapedat::date = v.scrapedat::date;");
+            await writer.WriteLineAsync();
+            await writer.WriteLineAsync("INSERT INTO pricehistory (name, currentprice, imageurl, scrapedat, offertype, shoptype, promotext)");
+            await writer.WriteLineAsync("SELECT v.name, v.currentprice, v.imageurl, v.scrapedat, v.offertype, v.shoptype, v.promotext");
+            await writer.WriteLineAsync("FROM v");
             await writer.WriteLineAsync("WHERE NOT EXISTS (");
             await writer.WriteLineAsync("  SELECT 1 FROM pricehistory ph");
             await writer.WriteLineAsync("  WHERE ph.name = v.name");


### PR DESCRIPTION
- replace insert-only pricehistory import with update + insert
- use WITH v(...) to update matching rows by name/shop/offer/date
- insert remaining rows not found in pricehistory
- include promotext and scrapedat in update
- 
Related Jira Key: BTS-104