### PR TITLE
BTS-110: Fix bugs

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^1.12.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-router-dom": "^6.30.3",
         "react-scripts": "5.0.1",
         "recharts": "^2.12.7",
         "typescript": "^4.9.5",
@@ -3507,6 +3508,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13764,6 +13773,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -20,8 +20,9 @@
     "axios": "^1.12.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "recharts": "^2.12.7",
+    "react-router-dom": "^6.30.3",
     "react-scripts": "5.0.1",
+    "recharts": "^2.12.7",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/client/web/src/AdminJobsPage.tsx
+++ b/client/web/src/AdminJobsPage.tsx
@@ -33,6 +33,7 @@ import {
 	YAxis,
 } from "recharts";
 import axios from "axios";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
 	fetchAdminHealth,
 	fetchAdminRuns,
@@ -183,9 +184,17 @@ export default function AdminJobsPage() {
 		React.useState<MatchJobStatus | null>(null);
 	const [preMatchLoading, setPreMatchLoading] = React.useState(false);
 	const [preMatchError, setPreMatchError] = React.useState<string | null>(null);
-	const [adminTab, setAdminTab] = React.useState<"schedules" | "prematch">(
-		"schedules",
-	);
+	const location = useLocation();
+	const navigate = useNavigate();
+	const adminTab = location.pathname.includes("/prematch")
+		? "prematch"
+		: "schedules";
+
+	React.useEffect(() => {
+		if (location.pathname === "/admin" || location.pathname === "/admin/") {
+			navigate("/admin/schedules", { replace: true });
+		}
+	}, [location.pathname, navigate]);
 
 	const selectedSchedule = React.useMemo(
 		() => schedules.find((s) => scheduleKey(s) === selectedKey) ?? null,
@@ -416,7 +425,11 @@ export default function AdminJobsPage() {
 
 				<Tabs
 					value={adminTab}
-					onChange={(_, value) => setAdminTab(value)}
+					onChange={(_, value) => {
+						const next =
+							value === "prematch" ? "/admin/prematch" : "/admin/schedules";
+						navigate(next);
+					}}
 					textColor="primary"
 					indicatorColor="primary"
 				>

--- a/client/web/src/App.tsx
+++ b/client/web/src/App.tsx
@@ -14,6 +14,7 @@ import {
 	Typography,
 } from "@mui/material";
 import React from "react";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import ProductsPage from "./ProductsPage";
 import LoginPage from "./LoginPage";
 import RegisterPage from "./RegisterPage";
@@ -36,13 +37,12 @@ function App() {
 	const [guestMode, setGuestMode] = React.useState(false);
 	const [isAdmin, setIsAdmin] = React.useState(false);
 	const [authView, setAuthView] = React.useState<"login" | "register">("login");
-	const [mainTab, setMainTab] = React.useState<
-		"products" | "receipts" | "favorites" | "admin"
-	>("products");
 	const [restrictedDialogOpen, setRestrictedDialogOpen] = React.useState(false);
 	const [pendingProtectedTab, setPendingProtectedTab] = React.useState<
 		"receipts" | "favorites" | "admin" | null
 	>(null);
+	const location = useLocation();
+	const navigate = useNavigate();
 
 	React.useEffect(() => {
 		const stored = getStoredToken();
@@ -78,15 +78,23 @@ function App() {
 		};
 	}, [token]);
 
-	React.useEffect(() => {
-		if (!isAdmin && mainTab === "admin") {
-			setMainTab("products");
-		}
-	}, [isAdmin, mainTab]);
-
 	const isAuthenticated = !!token;
 	const isGuest = guestMode && !isAuthenticated;
 	const showTabs = isAuthenticated || isGuest;
+	const mainTab = React.useMemo(() => {
+		const path = location.pathname.toLowerCase();
+		if (path.startsWith("/admin")) return "admin";
+		if (path.startsWith("/receipts")) return "receipts";
+		if (path.startsWith("/favorites")) return "favorites";
+		return "products";
+	}, [location.pathname]);
+	const adminDefaultPath = "/admin/schedules";
+	const adminPath = location.pathname.startsWith("/admin/")
+		? location.pathname
+		: adminDefaultPath;
+	const tabToPath = (
+		tab: "products" | "receipts" | "favorites" | "admin",
+	) => (tab === "admin" ? adminDefaultPath : `/${tab}`);
 
 	const handleLoggedIn = () => {
 		const stored = getStoredToken();
@@ -96,7 +104,8 @@ function App() {
 		setGuestMode(false);
 		clearGuestSession();
 		setAuthView("login");
-		setMainTab(pendingProtectedTab ?? "products");
+		const targetTab = pendingProtectedTab ?? "products";
+		navigate(tabToPath(targetTab), { replace: true });
 		setPendingProtectedTab(null);
 	};
 
@@ -106,7 +115,7 @@ function App() {
 		setToken(null);
 		setUserEmail(null);
 		setGuestMode(false);
-		setMainTab("products");
+		navigate("/products", { replace: true });
 	};
 
 	const handleGuestLogin = () => {
@@ -116,7 +125,7 @@ function App() {
 		setUserEmail(null);
 		setGuestMode(true);
 		setAuthView("login");
-		setMainTab("products");
+		navigate("/products", { replace: true });
 		setPendingProtectedTab(null);
 	};
 
@@ -138,7 +147,8 @@ function App() {
 			setRestrictedDialogOpen(true);
 			return;
 		}
-		setMainTab(val);
+		const targetPath = val === "admin" ? adminPath : `/${val}`;
+		navigate(targetPath);
 	};
 
 	const handleCloseRestrictedDialog = () => {
@@ -161,10 +171,7 @@ function App() {
 					: "this section";
 
 	const renderMainContent = () => {
-		if (!isAuthenticated) {
-			if (isGuest) {
-				return <ProductsPage />;
-			}
+		if (!isAuthenticated && !isGuest) {
 			return authView === "login" ? (
 				<LoginPage
 					onLoggedIn={handleLoggedIn}
@@ -179,19 +186,35 @@ function App() {
 			);
 		}
 
-		if (mainTab === "receipts") {
-			return <MyReceiptsPage />;
-		}
-
-		if (mainTab === "favorites") {
-			return <MyFavoritesPage />;
-		}
-
-		if (mainTab === "admin") {
-			return isAdmin ? <AdminJobsPage /> : <ProductsPage />;
-		}
-
-		return <ProductsPage />;
+		return (
+			<Routes>
+				<Route path="/" element={<Navigate to="/products" replace />} />
+				<Route path="/products" element={<ProductsPage />} />
+				<Route
+					path="/receipts"
+					element={
+						isAuthenticated ? <MyReceiptsPage /> : <Navigate to="/products" replace />
+					}
+				/>
+				<Route
+					path="/favorites"
+					element={
+						isAuthenticated ? <MyFavoritesPage /> : <Navigate to="/products" replace />
+					}
+				/>
+				<Route
+					path="/admin/*"
+					element={
+						isAuthenticated && isAdmin ? (
+							<AdminJobsPage />
+						) : (
+							<Navigate to="/products" replace />
+						)
+					}
+				/>
+				<Route path="*" element={<Navigate to="/products" replace />} />
+			</Routes>
+		);
 	};
 
 	return (

--- a/client/web/src/index.tsx
+++ b/client/web/src/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
@@ -9,7 +10,9 @@ const root = ReactDOM.createRoot(
 );
 root.render(
 	<React.StrictMode>
-		<App />
+		<BrowserRouter>
+			<App />
+		</BrowserRouter>
 	</React.StrictMode>,
 );
 

--- a/src/PriceCompareCore/Services/IngestionService.cs
+++ b/src/PriceCompareCore/Services/IngestionService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using PriceCompareCore.Interfaces;
@@ -54,7 +55,7 @@ namespace PriceCompareCore.Services
             var name = p.Name ?? string.Empty;
             var (sv, su, pk) = _mapper.ParseSpec(name);
             var catId = _mapper.MapCategoryId(name);
-            return new Product
+            var product = new Product
             {
                 ShopType = ShopType.COLES,
                 SourceId = p.Id > 0 ? p.Id.ToString() : null,
@@ -67,6 +68,8 @@ namespace PriceCompareCore.Services
                 ImageUrl = p.ImageUrl,
                 LastSeenAt = DateTime.UtcNow
             };
+            ApplyStandardFields(product);
+            return product;
         }
 
         private Product MapColesDown(ColesDownProduct p)
@@ -74,7 +77,7 @@ namespace PriceCompareCore.Services
             var name = p.Name ?? string.Empty;
             var (sv, su, pk) = _mapper.ParseSpec(name);
             var catId = _mapper.MapCategoryId(name);
-            return new Product
+            var product = new Product
             {
                 ShopType = ShopType.COLES,
                 SourceId = p.Id > 0 ? p.Id.ToString() : null,
@@ -87,6 +90,8 @@ namespace PriceCompareCore.Services
                 ImageUrl = p.ImageUrl,
                 LastSeenAt = DateTime.UtcNow
             };
+            ApplyStandardFields(product);
+            return product;
         }
 
         private Product MapWoolworthsSpecial(WoolworthsSpecialProduct p)
@@ -107,7 +112,7 @@ namespace PriceCompareCore.Services
                 sourceId = p.Stockcode.ToString();
             }
 
-            return new Product
+            var product = new Product
             {
                 ShopType = ShopType.WOOLWORTHS,
                 SourceId = sourceId,
@@ -120,6 +125,8 @@ namespace PriceCompareCore.Services
                 ImageUrl = p.LargeImageFile,
                 LastSeenAt = DateTime.UtcNow
             };
+            ApplyStandardFields(product);
+            return product;
         }
 
         // Upsert products into database
@@ -127,6 +134,8 @@ namespace PriceCompareCore.Services
         {
             foreach (var c in candidates)
             {
+                ApplyStandardFields(c);
+
                 Product? existing = null;
 
                 // try to find existing by (ShopType + SourceId)
@@ -156,11 +165,84 @@ namespace PriceCompareCore.Services
                     existing.PackageQty = c.PackageQty ?? existing.PackageQty;
                     existing.CategoryId = c.CategoryId ?? existing.CategoryId;
                     existing.ImageUrl = c.ImageUrl ?? existing.ImageUrl;
+                    ApplyStandardFields(existing);
                     existing.LastSeenAt = DateTime.UtcNow;
                 }
             }
 
             await _dbContext.SaveChangesAsync();
+        }
+
+        private static void ApplyStandardFields(Product product)
+        {
+            product.NormalizedName = NormalizeText(product.Name);
+            product.NormalizedBrand = NormalizeText(product.Brand);
+
+            var (stdValue, stdUnit, sizeUnknown) = StandardizeSize(product.SizeValue, product.SizeUnit);
+            product.SizeStandardValue = stdValue;
+            product.SizeStandardUnit = stdUnit;
+            product.SizeUnknown = sizeUnknown;
+
+            product.BrandUnknown = string.IsNullOrWhiteSpace(product.NormalizedBrand);
+            product.CategoryUnknown = !product.CategoryId.HasValue || product.CategoryId.Value <= 0;
+        }
+
+        private static string? NormalizeText(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            var sb = new StringBuilder(value.Length);
+            var lastWasSpace = false;
+            foreach (var ch in value)
+            {
+                if (char.IsLetterOrDigit(ch))
+                {
+                    sb.Append(char.ToLowerInvariant(ch));
+                    lastWasSpace = false;
+                }
+                else if (!lastWasSpace)
+                {
+                    sb.Append(' ');
+                    lastWasSpace = true;
+                }
+            }
+
+            var normalized = sb.ToString().Trim();
+            return normalized.Length == 0 ? null : normalized;
+        }
+
+        private static (decimal? value, string? unit, bool unknown) StandardizeSize(decimal? sizeValue, string? sizeUnit)
+        {
+            if (!sizeValue.HasValue || sizeValue.Value <= 0m || string.IsNullOrWhiteSpace(sizeUnit))
+            {
+                return (null, null, true);
+            }
+
+            var unit = sizeUnit.Trim().ToLowerInvariant();
+            switch (unit)
+            {
+                case "g":
+                    return (sizeValue.Value, "g", false);
+                case "kg":
+                    return (sizeValue.Value * 1000m, "g", false);
+                case "mg":
+                    return (sizeValue.Value / 1000m, "g", false);
+                case "ml":
+                    return (sizeValue.Value, "ml", false);
+                case "l":
+                case "lt":
+                case "ltr":
+                case "liter":
+                case "litre":
+                case "liters":
+                case "litres":
+                    return (sizeValue.Value * 1000m, "ml", false);
+                default:
+                    return (null, null, true);
+            }
         }
     }
 }

--- a/src/PriceCompareCore/Services/ScrapeExportService.cs
+++ b/src/PriceCompareCore/Services/ScrapeExportService.cs
@@ -136,7 +136,14 @@ namespace PriceCompareCore.Services
                 "packageqty",
                 "categoryid",
                 "imageurl",
-                "lastseenat"
+                "lastseenat",
+                "normalizedname",
+                "normalizedbrand",
+                "sizestandardvalue",
+                "sizestandardunit",
+                "sizeunknown",
+                "brandunknown",
+                "categoryunknown"
             };
 
             await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
@@ -157,7 +164,14 @@ namespace PriceCompareCore.Services
                     row.PackageQty?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
                     row.CategoryId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
                     row.ImageUrl ?? string.Empty,
-                    row.LastSeenAt.ToString("O", CultureInfo.InvariantCulture)
+                    row.LastSeenAt.ToString("O", CultureInfo.InvariantCulture),
+                    row.NormalizedName ?? string.Empty,
+                    row.NormalizedBrand ?? string.Empty,
+                    row.SizeStandardValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                    row.SizeStandardUnit ?? string.Empty,
+                    row.SizeUnknown ? "true" : "false",
+                    row.BrandUnknown ? "true" : "false",
+                    row.CategoryUnknown ? "true" : "false"
                 };
 
                 await CsvWriter.WriteRowAsync(writer, fields, ct);

--- a/src/PriceCompareWeb/Services/ScrapeImportSqlService.cs
+++ b/src/PriceCompareWeb/Services/ScrapeImportSqlService.cs
@@ -83,6 +83,17 @@ namespace PriceCompareWeb.Services
                 productRows = await WriteProductSqlAsync(writer, productPath, batchSize, ct);
             }
 
+            if (priceHistoryRows > 0)
+            {
+                await writer.WriteLineAsync("-- reset pricehistory id sequence");
+                await writer.WriteLineAsync("SELECT setval(");
+                await writer.WriteLineAsync("  pg_get_serial_sequence('pricehistory','id'),");
+                await writer.WriteLineAsync("  COALESCE((SELECT MAX(id) FROM pricehistory), 0) + 1,");
+                await writer.WriteLineAsync("  false");
+                await writer.WriteLineAsync(");");
+                await writer.WriteLineAsync();
+            }
+
             await writer.WriteLineAsync("COMMIT;");
 
             _logger.LogInformation("Generated SQL file at {Path}", outputPath);
@@ -326,21 +337,30 @@ namespace PriceCompareWeb.Services
             await writer.WriteLineAsync("  packageqty = COALESCE(d.packageqty, p.packageqty),");
             await writer.WriteLineAsync("  categoryid = COALESCE(d.categoryid, p.categoryid),");
             await writer.WriteLineAsync("  imageurl = COALESCE(d.imageurl, p.imageurl),");
+            await writer.WriteLineAsync("  normalizedname = d.normalizedname,");
+            await writer.WriteLineAsync("  normalizedbrand = d.normalizedbrand,");
+            await writer.WriteLineAsync("  sizestandardvalue = d.sizestandardvalue,");
+            await writer.WriteLineAsync("  sizestandardunit = d.sizestandardunit,");
+            await writer.WriteLineAsync("  sizeunknown = d.sizeunknown,");
+            await writer.WriteLineAsync("  brandunknown = d.brandunknown,");
+            await writer.WriteLineAsync("  categoryunknown = d.categoryunknown,");
             await writer.WriteLineAsync("  lastseenat = GREATEST(p.lastseenat, d.lastseenat)");
             await writer.WriteLineAsync("FROM (");
             await writer.WriteLineAsync("  SELECT DISTINCT ON (v.shoptype, v.sourceid)");
-            await writer.WriteLineAsync("    v.shoptype, v.sourceid, v.name, v.brand, v.sizevalue, v.sizeunit, v.packageqty, v.categoryid, v.imageurl, v.lastseenat");
+            await writer.WriteLineAsync("    v.shoptype, v.sourceid, v.name, v.brand, v.sizevalue, v.sizeunit, v.packageqty, v.categoryid, v.imageurl, v.lastseenat,");
+            await writer.WriteLineAsync("    v.normalizedname, v.normalizedbrand, v.sizestandardvalue, v.sizestandardunit,");
+            await writer.WriteLineAsync("    v.sizeunknown, v.brandunknown, v.categoryunknown");
             await writer.WriteLineAsync("  FROM (VALUES");
 
             for (var i = 0; i < batch.Count; i++)
             {
                 var row = batch[i];
-                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, false)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)})";
+                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, false)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)}, {Sql.Text(row.NormalizedName, true)}, {Sql.Text(row.NormalizedBrand, true)}, {Sql.Decimal(row.SizeStandardValue)}::numeric, {Sql.Text(row.SizeStandardUnit, true)}, {Sql.Bool(row.SizeUnknown)}, {Sql.Bool(row.BrandUnknown)}, {Sql.Bool(row.CategoryUnknown)})";
                 line += i == batch.Count - 1 ? string.Empty : ",";
                 await writer.WriteLineAsync(line);
             }
 
-            await writer.WriteLineAsync("  ) AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat)");
+            await writer.WriteLineAsync("  ) AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat, normalizedname, normalizedbrand, sizestandardvalue, sizestandardunit, sizeunknown, brandunknown, categoryunknown)");
             await writer.WriteLineAsync("  WHERE v.sourceid IS NOT NULL");
             await writer.WriteLineAsync("  ORDER BY v.shoptype, v.sourceid, v.lastseenat DESC, v.name DESC");
             await writer.WriteLineAsync(") AS d");
@@ -348,22 +368,24 @@ namespace PriceCompareWeb.Services
             await writer.WriteLineAsync("  AND p.sourceid = d.sourceid;");
             await writer.WriteLineAsync();
 
-            await writer.WriteLineAsync("INSERT INTO product (shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat)");
-            await writer.WriteLineAsync("SELECT d.shoptype, d.sourceid, d.name, d.brand, d.sizevalue, d.sizeunit, d.packageqty, d.categoryid, d.imageurl, d.lastseenat");
+            await writer.WriteLineAsync("INSERT INTO product (shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat, normalizedname, normalizedbrand, sizestandardvalue, sizestandardunit, sizeunknown, brandunknown, categoryunknown)");
+            await writer.WriteLineAsync("SELECT d.shoptype, d.sourceid, d.name, d.brand, d.sizevalue, d.sizeunit, d.packageqty, d.categoryid, d.imageurl, d.lastseenat, d.normalizedname, d.normalizedbrand, d.sizestandardvalue, d.sizestandardunit, d.sizeunknown, d.brandunknown, d.categoryunknown");
             await writer.WriteLineAsync("FROM (");
             await writer.WriteLineAsync("  SELECT DISTINCT ON (v.shoptype, v.sourceid)");
-            await writer.WriteLineAsync("    v.shoptype, v.sourceid, v.name, v.brand, v.sizevalue, v.sizeunit, v.packageqty, v.categoryid, v.imageurl, v.lastseenat");
+            await writer.WriteLineAsync("    v.shoptype, v.sourceid, v.name, v.brand, v.sizevalue, v.sizeunit, v.packageqty, v.categoryid, v.imageurl, v.lastseenat,");
+            await writer.WriteLineAsync("    v.normalizedname, v.normalizedbrand, v.sizestandardvalue, v.sizestandardunit,");
+            await writer.WriteLineAsync("    v.sizeunknown, v.brandunknown, v.categoryunknown");
             await writer.WriteLineAsync("  FROM (VALUES");
 
             for (var i = 0; i < batch.Count; i++)
             {
                 var row = batch[i];
-                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, false)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)})";
+                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, false)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)}, {Sql.Text(row.NormalizedName, true)}, {Sql.Text(row.NormalizedBrand, true)}, {Sql.Decimal(row.SizeStandardValue)}::numeric, {Sql.Text(row.SizeStandardUnit, true)}, {Sql.Bool(row.SizeUnknown)}, {Sql.Bool(row.BrandUnknown)}, {Sql.Bool(row.CategoryUnknown)})";
                 line += i == batch.Count - 1 ? string.Empty : ",";
                 await writer.WriteLineAsync(line);
             }
 
-            await writer.WriteLineAsync("  ) AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat)");
+            await writer.WriteLineAsync("  ) AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat, normalizedname, normalizedbrand, sizestandardvalue, sizestandardunit, sizeunknown, brandunknown, categoryunknown)");
             await writer.WriteLineAsync("  WHERE v.sourceid IS NOT NULL");
             await writer.WriteLineAsync("  ORDER BY v.shoptype, v.sourceid, v.lastseenat DESC, v.name DESC");
             await writer.WriteLineAsync(") AS d");
@@ -384,36 +406,43 @@ namespace PriceCompareWeb.Services
             await writer.WriteLineAsync("  packageqty = COALESCE(v.packageqty, p.packageqty),");
             await writer.WriteLineAsync("  categoryid = COALESCE(v.categoryid, p.categoryid),");
             await writer.WriteLineAsync("  imageurl = COALESCE(v.imageurl, p.imageurl),");
+            await writer.WriteLineAsync("  normalizedname = v.normalizedname,");
+            await writer.WriteLineAsync("  normalizedbrand = v.normalizedbrand,");
+            await writer.WriteLineAsync("  sizestandardvalue = v.sizestandardvalue,");
+            await writer.WriteLineAsync("  sizestandardunit = v.sizestandardunit,");
+            await writer.WriteLineAsync("  sizeunknown = v.sizeunknown,");
+            await writer.WriteLineAsync("  brandunknown = v.brandunknown,");
+            await writer.WriteLineAsync("  categoryunknown = v.categoryunknown,");
             await writer.WriteLineAsync("  lastseenat = GREATEST(p.lastseenat, v.lastseenat)");
             await writer.WriteLineAsync("FROM (VALUES");
 
             for (var i = 0; i < batch.Count; i++)
             {
                 var row = batch[i];
-                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, true)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)})";
+                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, true)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)}, {Sql.Text(row.NormalizedName, true)}, {Sql.Text(row.NormalizedBrand, true)}, {Sql.Decimal(row.SizeStandardValue)}::numeric, {Sql.Text(row.SizeStandardUnit, true)}, {Sql.Bool(row.SizeUnknown)}, {Sql.Bool(row.BrandUnknown)}, {Sql.Bool(row.CategoryUnknown)})";
                 line += i == batch.Count - 1 ? string.Empty : ",";
                 await writer.WriteLineAsync(line);
             }
 
-            await writer.WriteLineAsync(") AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat)");
+            await writer.WriteLineAsync(") AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat, normalizedname, normalizedbrand, sizestandardvalue, sizestandardunit, sizeunknown, brandunknown, categoryunknown)");
             await writer.WriteLineAsync("WHERE v.sourceid IS NULL");
             await writer.WriteLineAsync("  AND p.shoptype = v.shoptype");
             await writer.WriteLineAsync("  AND p.name = v.name;");
             await writer.WriteLineAsync();
 
-            await writer.WriteLineAsync("INSERT INTO product (shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat)");
-            await writer.WriteLineAsync("SELECT v.shoptype, v.sourceid, v.name, v.brand, v.sizevalue, v.sizeunit, v.packageqty, v.categoryid, v.imageurl, v.lastseenat");
+            await writer.WriteLineAsync("INSERT INTO product (shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat, normalizedname, normalizedbrand, sizestandardvalue, sizestandardunit, sizeunknown, brandunknown, categoryunknown)");
+            await writer.WriteLineAsync("SELECT v.shoptype, v.sourceid, v.name, v.brand, v.sizevalue, v.sizeunit, v.packageqty, v.categoryid, v.imageurl, v.lastseenat, v.normalizedname, v.normalizedbrand, v.sizestandardvalue, v.sizestandardunit, v.sizeunknown, v.brandunknown, v.categoryunknown");
             await writer.WriteLineAsync("FROM (VALUES");
 
             for (var i = 0; i < batch.Count; i++)
             {
                 var row = batch[i];
-                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, true)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)})";
+                var line = $"  ({Sql.Int(row.ShopType)}::int, {Sql.Text(row.SourceId, true)}, {Sql.Text(row.Name, false)}, {Sql.Text(row.Brand, true)}, {Sql.Decimal(row.SizeValue)}::numeric, {Sql.Text(row.SizeUnit, true)}, {Sql.Int(row.PackageQty)}::int, {Sql.Int(row.CategoryId)}::int, {Sql.Text(row.ImageUrl, true)}, {Sql.Timestamp(row.LastSeenAt)}, {Sql.Text(row.NormalizedName, true)}, {Sql.Text(row.NormalizedBrand, true)}, {Sql.Decimal(row.SizeStandardValue)}::numeric, {Sql.Text(row.SizeStandardUnit, true)}, {Sql.Bool(row.SizeUnknown)}, {Sql.Bool(row.BrandUnknown)}, {Sql.Bool(row.CategoryUnknown)})";
                 line += i == batch.Count - 1 ? string.Empty : ",";
                 await writer.WriteLineAsync(line);
             }
 
-            await writer.WriteLineAsync(") AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat)");
+            await writer.WriteLineAsync(") AS v(shoptype, sourceid, name, brand, sizevalue, sizeunit, packageqty, categoryid, imageurl, lastseenat, normalizedname, normalizedbrand, sizestandardvalue, sizestandardunit, sizeunknown, brandunknown, categoryunknown)");
             await writer.WriteLineAsync("WHERE v.sourceid IS NULL");
             await writer.WriteLineAsync("  AND NOT EXISTS (");
             await writer.WriteLineAsync("    SELECT 1 FROM product p");
@@ -469,10 +498,29 @@ namespace PriceCompareWeb.Services
             int? PackageQty,
             int? CategoryId,
             string? ImageUrl,
-            DateTime LastSeenAt)
+            DateTime LastSeenAt,
+            string NormalizedName,
+            string? NormalizedBrand,
+            decimal? SizeStandardValue,
+            string? SizeStandardUnit,
+            bool SizeUnknown,
+            bool BrandUnknown,
+            bool CategoryUnknown)
         {
             public static ProductRow FromCsv(IReadOnlyList<string> values, IReadOnlyDictionary<string, int> map)
             {
+                var normalizedBrand = Csv.Get(values, map, "normalizedbrand", required: false);
+                if (string.IsNullOrWhiteSpace(normalizedBrand))
+                {
+                    normalizedBrand = null;
+                }
+
+                var sizeStandardUnit = Csv.Get(values, map, "sizestandardunit", required: false);
+                if (string.IsNullOrWhiteSpace(sizeStandardUnit))
+                {
+                    sizeStandardUnit = null;
+                }
+
                 return new ProductRow(
                     Csv.Int(values, map, "shoptype"),
                     Csv.Get(values, map, "sourceid", required: false),
@@ -483,7 +531,14 @@ namespace PriceCompareWeb.Services
                     Csv.Int(values, map, "packageqty"),
                     Csv.Int(values, map, "categoryid"),
                     Csv.Get(values, map, "imageurl", required: false),
-                    Csv.Timestamp(values, map, "lastseenat"));
+                    Csv.Timestamp(values, map, "lastseenat"),
+                    Csv.Get(values, map, "normalizedname", required: true),
+                    normalizedBrand,
+                    Csv.DecimalNullable(values, map, "sizestandardvalue"),
+                    sizeStandardUnit,
+                    Csv.Bool(values, map, "sizeunknown"),
+                    Csv.Bool(values, map, "brandunknown"),
+                    Csv.Bool(values, map, "categoryunknown"));
             }
         }
 
@@ -504,6 +559,16 @@ namespace PriceCompareWeb.Services
 
             public static string Decimal(decimal? value)
                 => value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "NULL";
+
+            public static string Bool(bool? value)
+            {
+                if (!value.HasValue)
+                {
+                    return "NULL";
+                }
+
+                return value.Value ? "true" : "false";
+            }
 
             public static string Timestamp(DateTime value)
                 => $"'{value.ToUniversalTime():O}'::timestamptz";
@@ -578,6 +643,27 @@ namespace PriceCompareWeb.Services
                 }
 
                 throw new InvalidOperationException($"Invalid datetime in column '{column}'.");
+            }
+
+            public static bool Bool(IReadOnlyList<string> values, IReadOnlyDictionary<string, int> map, string column)
+            {
+                var raw = Get(values, map, column, required: true).Trim();
+                if (bool.TryParse(raw, out var parsed))
+                {
+                    return parsed;
+                }
+
+                if (string.Equals(raw, "1", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                if (string.Equals(raw, "0", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                throw new InvalidOperationException($"Invalid boolean in column '{column}'.");
             }
         }
 


### PR DESCRIPTION
Frontend routing added: Introduced react-router-dom, wrapped the app in BrowserRouter, and replaced tab state with URL-driven navigation. The app now uses <Routes> with auth guards, redirects / to /products, and routes /admin/* to the admin page. Admin tabs now update the URL and /admin redirects to /admin/schedules. Files: index.tsx, App.tsx, AdminJobsPage.tsx, package.json, package-lock.json.

Product normalization + standardization: Added normalized name/brand, standardized size units (g/ml), and “unknown” flags in ingestion. These fields are computed for mapped products and during upserts. File: IngestionService.cs.

Export/import pipeline extended: Product CSV export now includes normalized/standard fields and boolean flags. SQL import now writes/updates these fields for product rows, parses the new boolean columns, and resets the pricehistory sequence after import. Files: ScrapeExportService.cs, ScrapeImportSqlService.cs.

Related Jira Key: BTS-110