### PR TITLE
BTS-109 BTS-111: Optimized the pre-match API and the admin page.

### DIFF
--- a/client/web/src/AdminJobsPage.tsx
+++ b/client/web/src/AdminJobsPage.tsx
@@ -11,6 +11,7 @@ import {
 	FormControl,
 	InputLabel,
 	MenuItem,
+	OutlinedInput,
 	Select,
 	Stack,
 	Tab,
@@ -183,6 +184,8 @@ export default function AdminJobsPage() {
 	const [preMatchStatus, setPreMatchStatus] =
 		React.useState<MatchJobStatus | null>(null);
 	const [preMatchLoading, setPreMatchLoading] = React.useState(false);
+	const [preMatchStatusLoading, setPreMatchStatusLoading] =
+		React.useState(false);
 	const [preMatchError, setPreMatchError] = React.useState<string | null>(null);
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -370,7 +373,9 @@ export default function AdminJobsPage() {
 
 	const runPreMatch = React.useCallback(async () => {
 		setPreMatchError(null);
-		if (preMatchRequest.sourceShop === preMatchRequest.targetShop) {
+		const resumeJobId = preMatchRequest.resumeJobId?.trim();
+		const isResume = Boolean(resumeJobId);
+		if (!isResume && preMatchRequest.sourceShop === preMatchRequest.targetShop) {
 			setPreMatchError("Source shop and target shop must be different.");
 			return;
 		}
@@ -378,6 +383,7 @@ export default function AdminJobsPage() {
 		try {
 			const payload: MatchRunRequest = {
 				...preMatchRequest,
+				resumeJobId: resumeJobId || undefined,
 				limit:
 					preMatchRequest.limit != null
 						? Math.max(0, Number(preMatchRequest.limit))
@@ -401,6 +407,30 @@ export default function AdminJobsPage() {
 			setPreMatchLoading(false);
 		}
 	}, [preMatchRequest]);
+
+	const loadPreMatchStatus = React.useCallback(async () => {
+		setPreMatchError(null);
+		const jobId =
+			preMatchRequest.resumeJobId?.trim() || preMatchJobId || "";
+		if (!jobId) {
+			setPreMatchError("Provide a Job ID to load status.");
+			return;
+		}
+		setPreMatchStatusLoading(true);
+		try {
+			const status = await fetchMatchJobStatus(jobId);
+			setPreMatchStatus(status);
+			setPreMatchJobId(status.id);
+		} catch (e) {
+			if (axios.isAxiosError(e) && e.response?.status === 403) {
+				setPreMatchError("Not authorized to view pre-match status.");
+			} else {
+				setPreMatchError("Failed to load pre-match status.");
+			}
+		} finally {
+			setPreMatchStatusLoading(false);
+		}
+	}, [preMatchRequest.resumeJobId, preMatchJobId]);
 
 	return (
 		<Box>
@@ -562,6 +592,13 @@ export default function AdminJobsPage() {
 								>
 									{preMatchLoading ? "Starting..." : "Run pre-match"}
 								</Button>
+								<Button
+									variant="outlined"
+									onClick={loadPreMatchStatus}
+									disabled={preMatchStatusLoading}
+								>
+									{preMatchStatusLoading ? "Loading..." : "Refresh status"}
+								</Button>
 							</Stack>
 						</Stack>
 
@@ -631,6 +668,23 @@ export default function AdminJobsPage() {
 									<MenuItem value="incremental">Incremental</MenuItem>
 									<MenuItem value="full">Full</MenuItem>
 								</Select>
+							</FormControl>
+							<FormControl size="small" sx={{ minWidth: 220 }}>
+								<InputLabel id="pre-match-resume-label" shrink>
+									Resume Job ID
+								</InputLabel>
+								<OutlinedInput
+									label="Resume Job ID"
+									placeholder="Optional"
+									value={preMatchRequest.resumeJobId ?? ""}
+									onChange={(e) =>
+										setPreMatchRequest((prev) => ({
+											...prev,
+											resumeJobId: e.target.value,
+										}))
+									}
+									notched
+								/>
 							</FormControl>
 							<TextField
 								label="Limit"
@@ -726,6 +780,13 @@ export default function AdminJobsPage() {
 									<Typography variant="body2">
 										{shopLabel(preMatchStatus.sourceShop)} →{" "}
 										{shopLabel(preMatchStatus.targetShop)}
+									</Typography>
+									<Typography variant="body2">
+										Mode: {preMatchStatus.mode}, Top N: {preMatchStatus.topN},
+										{" "}Limit: {preMatchStatus.limitNum}
+									</Typography>
+									<Typography variant="body2">
+										Use LLM: {preMatchStatus.useLlm ? "Yes" : "No"}
 									</Typography>
 									<Typography variant="body2">
 										Progress: {preMatchStatus.processed}/{preMatchStatus.total}

--- a/client/web/src/ProductsPage.tsx
+++ b/client/web/src/ProductsPage.tsx
@@ -16,13 +16,18 @@ import {
 	Pagination,
 	LinearProgress,
 	Divider,
+	IconButton,
 } from "@mui/material";
+import FavoriteIcon from "@mui/icons-material/Favorite";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import { useMediaQuery, useTheme } from "@mui/material";
 import type { SelectChangeEvent } from "@mui/material/Select";
 import { SHOP_OPTIONS, shopTypeName } from "./constants/shopTypes";
 import { fetchProducts, type ProductRow } from "./api/products";
 import { useDebounce } from "./hooks/useDebounce";
 import CompareDialog from "./components/CompareDialog";
+import { addFavorite, fetchFavorites, removeFavorite } from "./api/favorites";
+import { getStoredToken } from "./api/auth";
 
 function formatSizeValue(value?: number | null) {
 	return value == null || Number.isNaN(value) ? "-" : String(value);
@@ -111,6 +116,7 @@ export default function ProductsPage() {
 	const theme = useTheme();
 	const isXs = useMediaQuery(theme.breakpoints.down("sm"));
 	const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
+	const isAuthenticated = Boolean(getStoredToken());
 	const [rows, setRows] = useState<ProductRow[]>([]);
 	const [rowCount, setRowCount] = useState(0);
 	const [loading, setLoading] = useState(false);
@@ -121,6 +127,8 @@ export default function ProductsPage() {
 		pageSize: 20,
 	});
 	const [refreshTick, setRefreshTick] = useState(0);
+	const [favoriteIds, setFavoriteIds] = useState<Set<string>>(new Set());
+	const [favoriteBusyIds, setFavoriteBusyIds] = useState<string[]>([]);
 
 	// Compare dialog state
 	const [compareOpen, setCompareOpen] = useState(false);
@@ -147,6 +155,63 @@ export default function ProductsPage() {
 		);
 		setCompareOpen(true);
 	};
+
+	const setFavoriteBusy = React.useCallback((productId: string, busy: boolean) => {
+		setFavoriteBusyIds((prev) => {
+			if (busy) {
+				return prev.includes(productId) ? prev : [...prev, productId];
+			}
+			return prev.filter((item) => item !== productId);
+		});
+	}, []);
+
+	const handleToggleFavorite = React.useCallback(
+		async (productId: string) => {
+			if (!isAuthenticated) {
+				alert("Please sign in to add items to My Favorites.");
+				return;
+			}
+			if (favoriteBusyIds.includes(productId)) return;
+			const wasFavorite = favoriteIds.has(productId);
+			setFavoriteBusy(productId, true);
+			setFavoriteIds((prev) => {
+				const next = new Set(prev);
+				if (wasFavorite) {
+					next.delete(productId);
+				} else {
+					next.add(productId);
+				}
+				return next;
+			});
+			try {
+				if (wasFavorite) {
+					await removeFavorite(productId);
+				} else {
+					await addFavorite(productId);
+				}
+			} catch (e) {
+				setFavoriteIds((prev) => {
+					const next = new Set(prev);
+					if (wasFavorite) {
+						next.add(productId);
+					} else {
+						next.delete(productId);
+					}
+					return next;
+				});
+				// eslint-disable-next-line no-console
+				console.error("Failed to toggle favorite", e);
+			} finally {
+				setFavoriteBusy(productId, false);
+			}
+		},
+		[
+			favoriteBusyIds,
+			favoriteIds,
+			isAuthenticated,
+			setFavoriteBusy,
+		],
+	);
 
 	// Fetch when filters or pagination changes
 	useEffect(() => {
@@ -181,6 +246,30 @@ export default function ProductsPage() {
 		paginationModel.pageSize,
 		refreshTick,
 	]);
+
+	useEffect(() => {
+		let active = true;
+		if (!isAuthenticated) {
+			setFavoriteIds(new Set());
+			return () => {
+				active = false;
+			};
+		}
+		const loadFavorites = async () => {
+			try {
+				const data = await fetchFavorites();
+				if (!active) return;
+				setFavoriteIds(new Set(data.map((item) => item.productId)));
+			} catch (e) {
+				// eslint-disable-next-line no-console
+				console.error("Failed to load favorites", e);
+			}
+		};
+		void loadFavorites();
+		return () => {
+			active = false;
+		};
+	}, [isAuthenticated]);
 
 	const totalPages = Math.max(
 		1,
@@ -291,6 +380,8 @@ export default function ProductsPage() {
 							const sizeText = formatSize(row);
 							const priceText = formatPrice(row.price, sizeText || undefined);
 							const accent = shopAccent(row.shopType);
+							const isFavorite = favoriteIds.has(row.productId);
+							const favoriteBusy = favoriteBusyIds.includes(row.productId);
 							return (
 								<Card
 									key={row.productId}
@@ -395,20 +486,51 @@ export default function ProductsPage() {
 												Size unit: {formatSizeUnit(row.sizeUnit)}
 											</Typography>
 										</Stack>
-										<Button
-											variant="contained"
-											size="small"
+										<Stack
+											direction="row"
+											spacing={1}
 											sx={{ mt: "auto", alignSelf: "center" }}
-											onClick={() =>
-												handleCompare(
-													row.productId,
-													row.name,
-													row.shopType,
-												)
-											}
+											alignItems="center"
 										>
-											Compare
-										</Button>
+											<Button
+												variant="contained"
+												size="small"
+												onClick={() =>
+													handleCompare(
+														row.productId,
+														row.name,
+														row.shopType,
+													)
+												}
+											>
+												Compare
+											</Button>
+											<IconButton
+												size="small"
+												onClick={() => void handleToggleFavorite(row.productId)}
+												disabled={favoriteBusy}
+												aria-label={
+													isFavorite
+														? "Remove from My Favorites"
+														: "Add to My Favorites"
+												}
+												sx={{
+													color: accent,
+													border: "1px solid",
+													borderColor: `${accent}33`,
+													bgcolor: "#ffffff",
+													"&:hover": {
+														bgcolor: `${accent}12`,
+													},
+												}}
+											>
+												{isFavorite ? (
+													<FavoriteIcon fontSize="small" />
+												) : (
+													<FavoriteBorderIcon fontSize="small" />
+												)}
+											</IconButton>
+										</Stack>
 									</CardContent>
 								</Card>
 							);

--- a/client/web/src/api/admin.ts
+++ b/client/web/src/api/admin.ts
@@ -94,6 +94,7 @@ export async function fetchAdminHealth(rangeHours = 24): Promise<AdminHealth> {
 }
 
 export type MatchRunRequest = {
+	resumeJobId?: string;
 	sourceShop: number;
 	targetShop: number;
 	mode?: string;

--- a/src/PriceCompareCore/Services/MatchJobService.cs
+++ b/src/PriceCompareCore/Services/MatchJobService.cs
@@ -28,28 +28,56 @@ namespace PriceCompareCore.Services
 
         public async Task<Guid> StartAsync(MatchRunRequest request)
         {
-            var jobId = Guid.NewGuid();
+            var jobId = request.ResumeJobId ?? Guid.NewGuid();
 
             using (var scope = _scopeFactory.CreateScope())
             {
                 var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
-                var job = new MatchJob
-                {
-                    Id = jobId,
-                    SourceShop = request.SourceShop,
-                    TargetShop = request.TargetShop,
-                    Status = "queued",
-                    Mode = string.IsNullOrWhiteSpace(request.Mode) ? "incremental" : request.Mode,
-                    Since = request.Since,
-                    UseLlm = request.UseLlm,
-                    LimitNum = request.Limit,
-                    TopN = request.TopN,
-                    CreatedAt = DateTime.UtcNow,
-                    UpdatedAt = DateTime.UtcNow
-                };
+                MatchJob? job = null;
 
-                db.MatchJobs.Add(job);
+                if (request.ResumeJobId.HasValue)
+                {
+                    job = await db.MatchJobs.FirstOrDefaultAsync(j => j.Id == request.ResumeJobId.Value);
+                    if (job == null)
+                    {
+                        throw new InvalidOperationException($"Resume job not found: {request.ResumeJobId}");
+                    }
+
+                    if (request.SourceShop != job.SourceShop || request.TargetShop != job.TargetShop)
+                    {
+                        throw new InvalidOperationException("Resume job source/target does not match.");
+                    }
+
+                    job.Status = "queued";
+                    request.Mode = job.Mode;
+                    request.Since = job.Since;
+                    request.UseLlm = job.UseLlm;
+                    request.Limit = job.LimitNum;
+                    request.TopN = job.TopN;
+                    job.ErrorMessage = null;
+                    job.UpdatedAt = DateTime.UtcNow;
+                }
+                else
+                {
+                    job = new MatchJob
+                    {
+                        Id = jobId,
+                        SourceShop = request.SourceShop,
+                        TargetShop = request.TargetShop,
+                        Status = "queued",
+                        Mode = string.IsNullOrWhiteSpace(request.Mode) ? "incremental" : request.Mode,
+                        Since = request.Since,
+                        UseLlm = request.UseLlm,
+                        LimitNum = request.Limit,
+                        TopN = request.TopN,
+                        CreatedAt = DateTime.UtcNow,
+                        UpdatedAt = DateTime.UtcNow
+                    };
+
+                    db.MatchJobs.Add(job);
+                }
+
                 await db.SaveChangesAsync();
             }
 
@@ -118,11 +146,29 @@ namespace PriceCompareCore.Services
                 await db.SaveChangesAsync();
 
                 IQueryable<Product> query = baseQuery
-                    .OrderByDescending(p => p.LastSeenAt);
+                    .OrderByDescending(p => p.LastSeenAt)
+                    .ThenByDescending(p => p.ProductId);
 
-                if (request.Limit > 0)
+                var remainingLimit = request.Limit;
+                if (request.ResumeJobId.HasValue && job.Processed > 0)
                 {
-                    query = query.Take(request.Limit);
+                    query = query.Skip(job.Processed);
+                    if (remainingLimit > 0)
+                    {
+                        remainingLimit = Math.Max(remainingLimit - job.Processed, 0);
+                    }
+                }
+
+                if (remainingLimit > 0)
+                {
+                    query = query.Take(remainingLimit);
+                }
+                else if (request.Limit > 0)
+                {
+                    job.Status = "completed";
+                    job.UpdatedAt = DateTime.UtcNow;
+                    await db.SaveChangesAsync();
+                    return;
                 }
 
                 // Process in pages to avoid loading too many rows at once.

--- a/src/PriceCompareData/DTOs/MatchRunRequest.cs
+++ b/src/PriceCompareData/DTOs/MatchRunRequest.cs
@@ -7,6 +7,7 @@ namespace PriceCompareData.DTOs
 {
     public class MatchRunRequest
     {
+        public Guid? ResumeJobId { get; set; }
         public int SourceShop { get; set; }
         public int TargetShop { get; set; }
         public string Mode { get; set; } = "incremental";


### PR DESCRIPTION
-Admin jobs now support resuming match runs: MatchRunRequest adds ResumeJobId, Admin Jobs UI adds a Resume Job ID input + refresh status button, validation adjusted, and more status details displayed.

-Match service supports resuming runs: reuse existing job parameters, skip already processed items, continue with the remaining limit, and mark complete when no remaining work.

-Products page adds Favorites: loads favorites when signed in, supports optimistic toggle add/remove with busy state, and adds a heart icon button in the UI.

Related Jira Key: BTS-109 BTS-111