### PR TITLE
BTS-116: Add Woolworths Autumn Price scraper; disable Summer Price trigger

### DIFF
--- a/src/PriceCompareCore/Interfaces/IWoolworthsAutumnPriceDomScraperService.cs
+++ b/src/PriceCompareCore/Interfaces/IWoolworthsAutumnPriceDomScraperService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PriceCompareData.Entities.Scraping;
+
+namespace PriceCompareCore.Interfaces
+{
+    public interface IWoolworthsAutumnPriceDomScraperService
+    {
+        Task<List<WoolworthsSpecialProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default);
+    }
+}

--- a/src/PriceCompareCore/Jobs/WwsAutumnPriceDomJob.cs
+++ b/src/PriceCompareCore/Jobs/WwsAutumnPriceDomJob.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using PriceCompareCore.Interfaces;
+using Quartz;
+
+namespace PriceCompareCore.Jobs
+{
+    public class WwsAutumnPriceDomJob : IJob
+    {
+        private readonly IWoolworthsAutumnPriceDomScraperService _scraperService;
+
+        public WwsAutumnPriceDomJob(IWoolworthsAutumnPriceDomScraperService scraperService)
+            => _scraperService = scraperService;
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            await ColesDomJobLock.Gate.WaitAsync(context.CancellationToken);
+            try { await _scraperService.ScrapeAsync(0, context.CancellationToken); }
+            finally { ColesDomJobLock.Gate.Release(); }
+        }
+    }
+}

--- a/src/PriceCompareCore/Services/WoolworthsAutumnPriceDomScraperService.cs
+++ b/src/PriceCompareCore/Services/WoolworthsAutumnPriceDomScraperService.cs
@@ -1,0 +1,618 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+using PriceCompareCore.Interfaces;
+using PriceCompareData.Common;
+using PriceCompareData.Data;
+using PriceCompareData.Entities.Common;
+using PriceCompareData.Entities.History;
+using PriceCompareData.Entities.Scraping;
+
+namespace PriceCompareCore.Services
+{
+    public class WoolworthsAutumnPriceDomScraperService : IWoolworthsAutumnPriceDomScraperService
+    {
+        private const string AutumnPriceUrl = "https://www.woolworths.com.au/shop/browse/specials/autumn-price";
+        private const string DefaultUa =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+        private const string AutumnPricePromoText = "autumn price";
+
+        private readonly ILogger<WoolworthsAutumnPriceDomScraperService> _logger;
+        private readonly IDistributedCache _cache;
+        private readonly AppDbContext _dbContext;
+        private readonly IIngestionService _ingestion;
+        private readonly IScrapeExportService _export;
+
+        public WoolworthsAutumnPriceDomScraperService(
+            ILogger<WoolworthsAutumnPriceDomScraperService> logger,
+            IDistributedCache cache,
+            AppDbContext dbContext,
+            IIngestionService ingestion,
+            IScrapeExportService export)
+        {
+            _logger = logger;
+            _cache = cache;
+            _dbContext = dbContext;
+            _ingestion = ingestion;
+            _export = export;
+        }
+
+        public async Task<List<WoolworthsSpecialProduct>> ScrapeAsync(int limit = 0, CancellationToken ct = default)
+        {
+            var hardCap = GetDomHardCap();
+            if (limit <= 0) limit = hardCap;
+            if (limit > hardCap) limit = hardCap;
+
+            var cached = await _cache.GetStringAsync(CacheKey.WOOLWORTHS_AUTUMN_PRICE_PRODUCTS, ct);
+            if (!string.IsNullOrWhiteSpace(cached))
+            {
+                _logger.LogInformation("WWS DOM: returning cached autumn-price products.");
+                var cachedItems = JsonSerializer.Deserialize<List<WoolworthsSpecialProduct>>(cached) ?? new();
+                return cachedItems.Take(limit).ToList();
+            }
+
+            var fetchLimit = hardCap;
+
+            using var pw = await Playwright.CreateAsync();
+            await using var browser = await pw.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = GetHeadless(),
+                SlowMo = GetSlowMoMs(),
+                Channel = GetChromeChannel(),
+                Args = new[]
+                {
+                    "--disable-dev-shm-usage",
+                    "--no-sandbox",
+                    "--disable-gpu",
+                    "--disable-features=IsolateOrigins,site-per-process",
+                    "--disable-blink-features=AutomationControlled"
+                }
+            });
+
+            await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+            {
+                Locale = "en-AU",
+                UserAgent = GetUserAgent(),
+                TimezoneId = "Australia/Sydney",
+                ViewportSize = new ViewportSize { Width = 1365, Height = 768 },
+                ScreenSize = new ScreenSize { Width = 1365, Height = 768 },
+                DeviceScaleFactor = 1,
+                IsMobile = false,
+                HasTouch = false,
+                ExtraHTTPHeaders = new Dictionary<string, string>
+                {
+                    ["Accept-Language"] = "en-AU,en;q=0.9",
+                    ["DNT"] = "1"
+                }
+            });
+
+            await context.AddInitScriptAsync(GetStealthScript());
+
+            var page = await context.NewPageAsync();
+            var domItems = new List<DomProduct>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var maxPages = GetMaxPages();
+            var startPage = GetStartPage();
+
+            for (var pageNumber = startPage; pageNumber <= maxPages && domItems.Count < fetchLimit; pageNumber++)
+            {
+                var url = BuildAutumnPriceUrl(pageNumber);
+                _logger.LogInformation("WWS DOM: goto autumn-price page {Page}...", pageNumber);
+                await page.GotoAsync(url, new PageGotoOptions
+                {
+                    WaitUntil = WaitUntilState.DOMContentLoaded,
+                    Timeout = 60000
+                });
+
+                await HumanDelayAsync(page, 1200, 2200);
+                if (pageNumber == startPage)
+                {
+                    await TryClickAsync(page, "button:has-text(\"Accept\")", 1500);
+                }
+                await HumanDelayAsync(page, 800, 1400);
+                await page.Mouse.MoveAsync(250, 250);
+                if (pageNumber == startPage)
+                {
+                    await TryDismissShopModalAsync(page);
+                }
+
+                var selector = await WaitForAnySelectorAsync(
+                    page,
+                    new[]
+                    {
+                        "a[href*='/shop/productdetails/']",
+                        "[data-testid*='product-tile']",
+                        "[data-testid*='product']"
+                    },
+                    20000);
+
+                if (selector is null)
+                {
+                    _logger.LogWarning("WWS DOM: no product selector detected on page {Page}.", pageNumber);
+                    break;
+                }
+
+                var remaining = fetchLimit - domItems.Count;
+                var pageItems = await ExtractDomItemsAsync(page, remaining, ct, seen, GetMaxScrollRounds());
+                _logger.LogInformation("WWS DOM: page {Page} -> {Count} items.", pageNumber, pageItems.Count);
+
+                if (pageItems.Count == 0)
+                {
+                    break;
+                }
+
+                domItems.AddRange(pageItems);
+            }
+
+            var scrapedAt = DateTime.UtcNow;
+            var mapped = MapDomItems(domItems, scrapedAt);
+            _logger.LogInformation("WWS DOM: extracted {Count} products.", mapped.Count);
+
+            var serialized = JsonSerializer.Serialize(mapped);
+            await _cache.SetStringAsync(
+                CacheKey.WOOLWORTHS_AUTUMN_PRICE_PRODUCTS,
+                serialized,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(60)
+                },
+                ct);
+
+            await PersistAndExportAsync(mapped, scrapedAt, ct);
+
+            return mapped.Take(limit).ToList();
+        }
+
+        private async Task PersistAndExportAsync(
+            IReadOnlyList<WoolworthsSpecialProduct> products,
+            DateTime scrapedAt,
+            CancellationToken ct)
+        {
+            if (products.Count == 0)
+            {
+                return;
+            }
+
+            var today = scrapedAt.Date;
+            var priceHistoryRows = new List<PriceHistory>(products.Count);
+
+            foreach (var product in products)
+            {
+                var existing = _dbContext.PriceHistory.FirstOrDefault(ph =>
+                    ph.Name == product.DisplayName &&
+                    ph.ShopType == ShopType.WOOLWORTHS &&
+                    ph.OfferType == OfferType.AUTUMN_PRICE &&
+                    ph.ScrapedAt >= today &&
+                    ph.ScrapedAt < today.AddDays(1));
+
+                var priceHistory = new PriceHistory
+                {
+                    Name = product.DisplayName,
+                    ImageUrl = product.LargeImageFile ?? string.Empty,
+                    CurrentPrice = product.Price,
+                    ScrapedAt = scrapedAt,
+                    OfferType = OfferType.AUTUMN_PRICE,
+                    ShopType = ShopType.WOOLWORTHS,
+                    PromoText = AutumnPricePromoText
+                };
+
+                priceHistoryRows.Add(priceHistory);
+
+                if (existing is null)
+                {
+                    _dbContext.PriceHistory.Add(priceHistory);
+                }
+                else if (!string.Equals(existing.PromoText, AutumnPricePromoText, StringComparison.OrdinalIgnoreCase))
+                {
+                    existing.PromoText = AutumnPricePromoText;
+                }
+            }
+
+            await _dbContext.SaveChangesAsync(ct);
+            await _ingestion.UpsertWwsAsync(products);
+            var productRows = _ingestion.MapWoolworthsProducts(products);
+            await _export.ExportAsync(
+                new ScrapeExportRequest(
+                    "woolworths_autumn_price",
+                    scrapedAt,
+                    priceHistoryRows,
+                    productRows),
+                ct);
+        }
+
+        private static List<WoolworthsSpecialProduct> MapDomItems(IReadOnlyList<DomProduct> items, DateTime scrapedAt)
+        {
+            var result = new List<WoolworthsSpecialProduct>();
+            foreach (var item in items)
+            {
+                var name = item.Name?.Trim() ?? string.Empty;
+                if (!IsValidName(name))
+                {
+                    continue;
+                }
+
+                var price = ParseMoney(ExtractFromAria(item.Aria, "Non-member price"));
+                var was = ParseMoney(ExtractFromAria(item.Aria, "Was"));
+                if (!price.HasValue)
+                {
+                    continue;
+                }
+                var savings = (was.HasValue && price.HasValue && was.Value > price.Value)
+                    ? was.Value - price.Value
+                    : (decimal?)null;
+
+                result.Add(new WoolworthsSpecialProduct
+                {
+                    Stockcode = 0,
+                    Barcode = string.Empty,
+                    DisplayName = name,
+                    Brand = string.Empty,
+                    Price = price ?? 0m,
+                    WasPrice = was,
+                    SavingsAmount = savings,
+                    IsOnSpecial = true,
+                    CupPrice = null,
+                    CupString = null,
+                    LargeImageFile = item.Image,
+                    PromoText = AutumnPricePromoText,
+                    ScrapedAt = scrapedAt
+                });
+            }
+
+            return result;
+        }
+
+        private static decimal? ParseMoney(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return null;
+            }
+
+            var cleaned = raw.Replace("Was", "", StringComparison.OrdinalIgnoreCase)
+                .Replace("$", "", StringComparison.OrdinalIgnoreCase)
+                .Replace(" ", "");
+
+            return decimal.TryParse(cleaned, NumberStyles.Number, CultureInfo.InvariantCulture, out var value)
+                ? value
+                : null;
+        }
+
+        private static string? ExtractFromAria(string? aria, string key)
+        {
+            if (string.IsNullOrWhiteSpace(aria))
+            {
+                return null;
+            }
+
+            var marker = key + " ";
+            var idx = aria.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0)
+            {
+                return null;
+            }
+
+            var start = idx + marker.Length;
+            var end = aria.IndexOf(',', start);
+            if (end < 0)
+            {
+                end = aria.Length;
+            }
+
+            var segment = aria.Substring(start, end - start).Trim();
+            return segment.StartsWith("$", StringComparison.OrdinalIgnoreCase) ? segment : "$" + segment;
+        }
+
+        private static async Task<List<DomProduct>> ExtractDomItemsAsync(
+            IPage page,
+            int limit,
+            CancellationToken ct,
+            HashSet<string> seen,
+            int maxRounds)
+        {
+            var results = new List<DomProduct>();
+
+            var locator = page.Locator("a[href*='/shop/productdetails/'][aria-label]");
+            var stableRounds = 0;
+
+            while (results.Count < limit && stableRounds < 3 && maxRounds-- > 0)
+            {
+                var before = results.Count;
+                var total = await locator.CountAsync();
+
+                for (var i = 0; i < total && results.Count < limit; i++)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        return results;
+                    }
+
+                    var anchor = locator.Nth(i);
+                    var href = (await anchor.GetAttributeAsync("href")) ?? string.Empty;
+                    if (string.IsNullOrWhiteSpace(href))
+                    {
+                        continue;
+                    }
+
+                    var fullHref = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                        ? href
+                        : new Uri(new Uri(AutumnPriceUrl), href).ToString();
+
+                    if (!seen.Add(fullHref))
+                    {
+                        continue;
+                    }
+
+                    var aria = (await anchor.GetAttributeAsync("aria-label")) ?? string.Empty;
+                    if (!IsProductAria(aria))
+                    {
+                        continue;
+                    }
+
+                    var name = ExtractNameFromAria(aria);
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        name = (await anchor.InnerTextAsync()).Trim();
+                    }
+
+                    string image = string.Empty;
+                    var img = anchor.Locator("img");
+                    if (await img.CountAsync() > 0)
+                    {
+                        image = (await img.First.GetAttributeAsync("src"))
+                                ?? (await img.First.GetAttributeAsync("data-src"))
+                                ?? string.Empty;
+                    }
+
+                    results.Add(new DomProduct
+                    {
+                        Name = name,
+                        Href = fullHref,
+                        Image = image,
+                        Aria = aria
+                    });
+                }
+
+                if (results.Count == before)
+                {
+                    stableRounds++;
+                }
+                else
+                {
+                    stableRounds = 0;
+                }
+
+                if (results.Count >= limit)
+                {
+                    break;
+                }
+
+                await page.EvaluateAsync("() => window.scrollBy(0, document.body.scrollHeight)");
+                await HumanDelayAsync(page, 700, 1200);
+            }
+
+            return results;
+        }
+
+        private static string GetUserAgent()
+        {
+            var ua = Environment.GetEnvironmentVariable("WWS_USER_AGENT");
+            return string.IsNullOrWhiteSpace(ua) ? DefaultUa : ua.Trim();
+        }
+
+        private static int GetSlowMoMs()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_SLOWMO_MS");
+            return int.TryParse(raw, out var ms) && ms >= 0 ? ms : 60;
+        }
+
+        private static bool GetHeadless()
+        {
+            var headful = Environment.GetEnvironmentVariable("WWS_HEADFUL");
+            return !string.Equals(headful, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string? GetChromeChannel()
+        {
+            var useChrome = Environment.GetEnvironmentVariable("WWS_USE_CHROME_CHANNEL");
+            return string.Equals(useChrome, "true", StringComparison.OrdinalIgnoreCase) ? "chrome" : null;
+        }
+
+        private static async Task<bool> TryClickAsync(IPage page, string selector, int timeoutMs)
+        {
+            try
+            {
+                await page.ClickAsync(selector, new PageClickOptions { Timeout = timeoutMs });
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static async Task HumanDelayAsync(IPage page, int minMs, int maxMs)
+        {
+            if (minMs < 0) minMs = 0;
+            if (maxMs < minMs) maxMs = minMs;
+            var delay = Random.Shared.Next(minMs, maxMs + 1);
+            await page.WaitForTimeoutAsync(delay);
+        }
+
+        private static async Task<string?> WaitForAnySelectorAsync(IPage page, IReadOnlyList<string> selectors, int timeoutMs)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                foreach (var selector in selectors)
+                {
+                    try
+                    {
+                        var count = await page.Locator(selector).CountAsync();
+                        if (count > 0)
+                        {
+                            return selector;
+                        }
+                    }
+                    catch
+                    {
+                        // ignore and keep polling
+                    }
+                }
+
+                await page.WaitForTimeoutAsync(500);
+            }
+
+            return null;
+        }
+
+        private static async Task TryDismissShopModalAsync(IPage page)
+        {
+            var modalTitle = page.Locator("text=How would you like to shop?");
+            if (await modalTitle.CountAsync() == 0)
+            {
+                return;
+            }
+
+            await TryClickAsync(page, "button[aria-label='Close']", 1500);
+            await TryClickAsync(page, "button:has-text('Close')", 1500);
+
+            await TryClickAsync(page, "text=Delivery", 1500);
+            await TryClickAsync(page, "button:has-text('Save & continue')", 2000);
+
+            try
+            {
+                await page.Mouse.ClickAsync(50, 50);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            try
+            {
+                await modalTitle.First.WaitForAsync(new LocatorWaitForOptions
+                {
+                    State = WaitForSelectorState.Hidden,
+                    Timeout = 8000
+                });
+            }
+            catch
+            {
+                // ignore - modal may persist, we will still try selectors
+            }
+        }
+
+        private static string GetStealthScript()
+        {
+            return @"
+Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+Object.defineProperty(navigator, 'languages', { get: () => ['en-AU', 'en'] });
+Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+window.chrome = window.chrome || { runtime: {} };
+const originalQuery = window.navigator.permissions.query;
+window.navigator.permissions.query = (parameters) => (
+  parameters.name === 'notifications'
+    ? Promise.resolve({ state: Notification.permission })
+    : originalQuery(parameters)
+);
+";
+        }
+
+        private static int GetDomHardCap()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_MAX_ITEMS");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 1000;
+        }
+
+        private static int GetMaxScrollRounds()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_MAX_ROUNDS");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 6;
+        }
+
+        private static int GetMaxPages()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_MAX_PAGES");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 50;
+        }
+
+        private static int GetStartPage()
+        {
+            var raw = Environment.GetEnvironmentVariable("WWS_DOM_START_PAGE");
+            return int.TryParse(raw, out var v) && v > 0 ? v : 1;
+        }
+
+        private static string BuildAutumnPriceUrl(int pageNumber)
+            => $"{AutumnPriceUrl}?pageNumber={pageNumber}";
+
+        private sealed class DomProduct
+        {
+            public string? Name { get; set; }
+            public string? Href { get; set; }
+            public string? Image { get; set; }
+            public string? Aria { get; set; }
+        }
+
+        private static bool IsProductAria(string? aria)
+        {
+            if (string.IsNullOrWhiteSpace(aria))
+            {
+                return false;
+            }
+
+            return aria.Contains("Non-member price", StringComparison.OrdinalIgnoreCase) ||
+                   aria.Contains("Find out more about", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ExtractNameFromAria(string? aria)
+        {
+            if (string.IsNullOrWhiteSpace(aria))
+            {
+                return string.Empty;
+            }
+
+            if (aria.Contains("Find out more about", StringComparison.OrdinalIgnoreCase))
+            {
+                var start = aria.IndexOf("Find out more about", StringComparison.OrdinalIgnoreCase);
+                if (start >= 0)
+                {
+                    var tail = aria.Substring(start + "Find out more about".Length).Trim();
+                    var comma = tail.IndexOf(',', StringComparison.Ordinal);
+                    return (comma > 0 ? tail[..comma] : tail).Trim();
+                }
+            }
+
+            var firstPeriod = aria.IndexOf('.', StringComparison.Ordinal);
+            return firstPeriod > 0 ? aria[..firstPeriod].Trim() : aria.Trim();
+        }
+
+        private static bool IsValidName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            if (string.Equals(name, "out of stock", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!name.Any(char.IsLetter))
+            {
+                return false;
+            }
+
+            return name.Length >= 3;
+        }
+    }
+}

--- a/src/PriceCompareData/Common/CacheKey.cs
+++ b/src/PriceCompareData/Common/CacheKey.cs
@@ -36,5 +36,6 @@ namespace PriceCompareData.Entities.Common
         public const string WOOLWORTHS_HALF_PRICE_PRODUCTS = "WoolworthsHalfPriceProducts";
         public const string WOOLWORTHS_BUY_MORE_SAVE_MORE_PRODUCTS = "WoolworthsBuyMoreSaveMoreProducts";
         public const string WOOLWORTHS_SUMMER_PRICE_PRODUCTS = "WoolworthsSummerPriceProducts";
+        public const string WOOLWORTHS_AUTUMN_PRICE_PRODUCTS = "WoolworthsAutumnPriceProducts";
     }
 }

--- a/src/PriceCompareData/Common/OfferType.cs
+++ b/src/PriceCompareData/Common/OfferType.cs
@@ -33,5 +33,6 @@ namespace PriceCompareData.Common
         public const int DELIVER_MORE_RANGE = 23;
         public const int BUY_MORE_SAVE_MORE = 24;
         public const int SUMMER_PRICE = 25;
+        public const int AUTUMN_PRICE = 26;
     }
 }

--- a/src/PriceCompareData/Common/WebInfo.cs
+++ b/src/PriceCompareData/Common/WebInfo.cs
@@ -9,7 +9,7 @@ namespace PriceCompareData.Entities.Common
     {
         public const string COLES_BASE_URL = "https://www.coles.com.au";
         // Next.js build id used in Coles _next/data URLs. Update this when Coles deploys.
-        public const string COLES_NEXT_BUILD_ID = "20260127.7-95792a7a1587133fb3156d8da8fe0d2cb20a640a";
+        public const string COLES_NEXT_BUILD_ID = "20260226.8-d17cfe0a58d12bdda7eb0bae264e48600cd2d6a6";
         public const string COLES_NEXT_DATA_BASE = COLES_BASE_URL + "/_next/data/" + COLES_NEXT_BUILD_ID;
     }
 }

--- a/src/PriceCompareWeb/Controllers/ScrapingController.cs
+++ b/src/PriceCompareWeb/Controllers/ScrapingController.cs
@@ -42,6 +42,7 @@ namespace PriceCompareWeb.Controllers
         private readonly IWoolworthsHalfPriceDomScraperService _wwsHalfPriceDomService;
         private readonly IWoolworthsBuyMoreSaveMoreDomScraperService _wwsBuyMoreSaveMoreDomService;
         private readonly IWoolworthsSummerPriceDomScraperService _wwsSummerPriceDomService;
+        private readonly IWoolworthsAutumnPriceDomScraperService _wwsAutumnPriceDomService;
 
         public ScrapingController(IColesDownScraperService scraperService,
         ILogger<ScrapingController> logger,
@@ -71,7 +72,8 @@ namespace PriceCompareWeb.Controllers
         IWoolworthsEverydayLowPriceDomScraperService wwsEverydayLowPriceDomService,
         IWoolworthsHalfPriceDomScraperService wwsHalfPriceDomService,
         IWoolworthsBuyMoreSaveMoreDomScraperService wwsBuyMoreSaveMoreDomScraperService,
-        IWoolworthsSummerPriceDomScraperService wwsSummerPriceDomScraperService)
+        IWoolworthsSummerPriceDomScraperService wwsSummerPriceDomScraperService,
+        IWoolworthsAutumnPriceDomScraperService wwsAutumnPriceDomScraperService)
         {
             _scraperService = scraperService;
             _logger = logger;
@@ -102,6 +104,7 @@ namespace PriceCompareWeb.Controllers
             _wwsHalfPriceDomService = wwsHalfPriceDomService;
             _wwsBuyMoreSaveMoreDomService = wwsBuyMoreSaveMoreDomScraperService;
             _wwsSummerPriceDomService = wwsSummerPriceDomScraperService;
+            _wwsAutumnPriceDomService = wwsAutumnPriceDomScraperService;
         }
 
         [HttpGet("coles/down-down/all")]
@@ -645,6 +648,21 @@ namespace PriceCompareWeb.Controllers
             {
                 _logger.LogError(ex, "Failed to get Woolworths summer-price DOM products");
                 return StatusCode(500, "Failed to get Woolworths summer-price DOM products");
+            }
+        }
+
+        [HttpGet("woolworths/autumn-price/dom")]
+        public async Task<IActionResult> GetWoolworthsAutumnPriceDom([FromQuery] int limit = 0)
+        {
+            try
+            {
+                var products = await _wwsAutumnPriceDomService.ScrapeAsync(limit, HttpContext.RequestAborted);
+                return Ok(new { Count = products.Count, Products = products });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get Woolworths autumn-price DOM products");
+                return StatusCode(500, "Failed to get Woolworths autumn-price DOM products");
             }
         }
 

--- a/src/PriceCompareWeb/Program.cs
+++ b/src/PriceCompareWeb/Program.cs
@@ -149,7 +149,7 @@ if (enableQuartzJobs)
         q.AddTrigger(opts => opts
             .ForJob(jobKey)
             .WithIdentity("ColesRefreshJob-trigger")
-            .WithCronSchedule("0 30 17 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 0 ? * WED", x => x.InTimeZone(localTz)));
 
         // scrape data - coles on special (no scheduled trigger)
 
@@ -159,7 +159,7 @@ if (enableQuartzJobs)
         q.AddTrigger(opts => opts
             .ForJob(jobKeyWwsLowerShelf)
             .WithIdentity("WwsLowerShelfDomJob-trigger")
-            .WithCronSchedule("0 30 3 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 10 ? * WED", x => x.InTimeZone(localTz)));
 
         // scrape data - woolworths everyday low price (DOM)
         var jobKeyWwsEverydayLow = new JobKey("WwsEverydayLowPriceDomJob");
@@ -167,7 +167,7 @@ if (enableQuartzJobs)
         q.AddTrigger(opts => opts
             .ForJob(jobKeyWwsEverydayLow)
             .WithIdentity("WwsEverydayLowPriceDomJob-trigger")
-            .WithCronSchedule("0 0 4 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 10 ? * WED", x => x.InTimeZone(localTz)));
 
         // scrape data - woolworths half price (DOM)
         var jobKeyWwsHalfPrice = new JobKey("WwsHalfPriceDomJob");
@@ -175,7 +175,7 @@ if (enableQuartzJobs)
         q.AddTrigger(opts => opts
             .ForJob(jobKeyWwsHalfPrice)
             .WithIdentity("WwsHalfPriceDomJob-trigger")
-            .WithCronSchedule("0 30 4 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 11 ? * WED", x => x.InTimeZone(localTz)));
 
         // scrape data - woolworths buy more save more (DOM)
         var jobKeyWwsBuyMoreSaveMore = new JobKey("WwsBuyMoreSaveMoreDomJob");
@@ -183,149 +183,153 @@ if (enableQuartzJobs)
         q.AddTrigger(opts => opts
             .ForJob(jobKeyWwsBuyMoreSaveMore)
             .WithIdentity("WwsBuyMoreSaveMoreDomJob-trigger")
-            .WithCronSchedule("0 30 5 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 12 ? * WED", x => x.InTimeZone(localTz)));
 
-        // scrape data - woolworths summer price (DOM)
+        // scrape data - woolworths summer price (DOM) - schedule disabled; replaced by autumn-price
         var jobKeyWwsSummerPrice = new JobKey("WwsSummerPriceDomJob");
-        q.AddJob<WwsSummerPriceDomJob>(opts => opts.WithIdentity(jobKeyWwsSummerPrice));
-        q.AddTrigger(opts => opts
-            .ForJob(jobKeyWwsSummerPrice)
-            .WithIdentity("WwsSummerPriceDomJob-trigger")
-            .WithCronSchedule("0 0 6 ? * TUE", x => x.InTimeZone(localTz)));
+        q.AddJob<WwsSummerPriceDomJob>(opts => opts.WithIdentity(jobKeyWwsSummerPrice).StoreDurably());
 
-        // weekly sequential scrape - coles DOM categories (Mon 17:30 local, every 30 mins)
+        // scrape data - woolworths autumn price (DOM)
+        var jobKeyWwsAutumnPrice = new JobKey("WwsAutumnPriceDomJob");
+        q.AddJob<WwsAutumnPriceDomJob>(opts => opts.WithIdentity(jobKeyWwsAutumnPrice));
+        q.AddTrigger(opts => opts
+            .ForJob(jobKeyWwsAutumnPrice)
+            .WithIdentity("WwsAutumnPriceDomJob-trigger")
+            .WithCronSchedule("0 40 12 ? * WED", x => x.InTimeZone(localTz)));
+
+        // weekly sequential scrape - coles DOM categories (Wed 00:10 local, every 30 mins)
         var jobKeyColesMeatSeafood = new JobKey("ColesMeatSeafoodDomJob");
         q.AddJob<ColesMeatSeafoodDomJob>(opts => opts.WithIdentity(jobKeyColesMeatSeafood));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesMeatSeafood)
             .WithIdentity("ColesMeatSeafoodDomJob-trigger")
-            .WithCronSchedule("0 0 18 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 0 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesFruitVegetables = new JobKey("ColesFruitVegetablesDomJob");
         q.AddJob<ColesFruitVegetablesDomJob>(opts => opts.WithIdentity(jobKeyColesFruitVegetables));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesFruitVegetables)
             .WithIdentity("ColesFruitVegetablesDomJob-trigger")
-            .WithCronSchedule("0 30 18 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 1 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesDairyEggsFridge = new JobKey("ColesDairyEggsFridgeDomJob");
         q.AddJob<ColesDairyEggsFridgeDomJob>(opts => opts.WithIdentity(jobKeyColesDairyEggsFridge));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesDairyEggsFridge)
             .WithIdentity("ColesDairyEggsFridgeDomJob-trigger")
-            .WithCronSchedule("0 0 19 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 1 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesBakery = new JobKey("ColesBakeryDomJob");
         q.AddJob<ColesBakeryDomJob>(opts => opts.WithIdentity(jobKeyColesBakery));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesBakery)
             .WithIdentity("ColesBakeryDomJob-trigger")
-            .WithCronSchedule("0 30 19 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 2 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesDeli = new JobKey("ColesDeliDomJob");
         q.AddJob<ColesDeliDomJob>(opts => opts.WithIdentity(jobKeyColesDeli));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesDeli)
             .WithIdentity("ColesDeliDomJob-trigger")
-            .WithCronSchedule("0 0 20 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 2 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesPantry = new JobKey("ColesPantryDomJob");
         q.AddJob<ColesPantryDomJob>(opts => opts.WithIdentity(jobKeyColesPantry));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesPantry)
             .WithIdentity("ColesPantryDomJob-trigger")
-            .WithCronSchedule("0 30 20 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 3 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesDietaryWorldFoods = new JobKey("ColesDietaryWorldFoodsDomJob");
         q.AddJob<ColesDietaryWorldFoodsDomJob>(opts => opts.WithIdentity(jobKeyColesDietaryWorldFoods));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesDietaryWorldFoods)
             .WithIdentity("ColesDietaryWorldFoodsDomJob-trigger")
-            .WithCronSchedule("0 0 21 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 3 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesChipsChocolatesSnacks = new JobKey("ColesChipsChocolatesSnacksDomJob");
         q.AddJob<ColesChipsChocolatesSnacksDomJob>(opts => opts.WithIdentity(jobKeyColesChipsChocolatesSnacks));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesChipsChocolatesSnacks)
             .WithIdentity("ColesChipsChocolatesSnacksDomJob-trigger")
-            .WithCronSchedule("0 30 21 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 4 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesDrinks = new JobKey("ColesDrinksDomJob");
         q.AddJob<ColesDrinksDomJob>(opts => opts.WithIdentity(jobKeyColesDrinks));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesDrinks)
             .WithIdentity("ColesDrinksDomJob-trigger")
-            .WithCronSchedule("0 0 22 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 4 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesLiquorland = new JobKey("ColesLiquorlandDomJob");
         q.AddJob<ColesLiquorlandDomJob>(opts => opts.WithIdentity(jobKeyColesLiquorland));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesLiquorland)
             .WithIdentity("ColesLiquorlandDomJob-trigger")
-            .WithCronSchedule("0 30 22 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 5 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesFrozen = new JobKey("ColesFrozenDomJob");
         q.AddJob<ColesFrozenDomJob>(opts => opts.WithIdentity(jobKeyColesFrozen));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesFrozen)
             .WithIdentity("ColesFrozenDomJob-trigger")
-            .WithCronSchedule("0 0 23 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 5 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesCleaningLaundry = new JobKey("ColesCleaningLaundryDomJob");
         q.AddJob<ColesCleaningLaundryDomJob>(opts => opts.WithIdentity(jobKeyColesCleaningLaundry));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesCleaningLaundry)
             .WithIdentity("ColesCleaningLaundryDomJob-trigger")
-            .WithCronSchedule("0 30 23 ? * MON", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 6 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesHealthBeauty = new JobKey("ColesHealthBeautyDomJob");
         q.AddJob<ColesHealthBeautyDomJob>(opts => opts.WithIdentity(jobKeyColesHealthBeauty));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesHealthBeauty)
             .WithIdentity("ColesHealthBeautyDomJob-trigger")
-            .WithCronSchedule("0 0 0 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 6 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesBaby = new JobKey("ColesBabyDomJob");
         q.AddJob<ColesBabyDomJob>(opts => opts.WithIdentity(jobKeyColesBaby));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesBaby)
             .WithIdentity("ColesBabyDomJob-trigger")
-            .WithCronSchedule("0 30 0 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 7 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesPet = new JobKey("ColesPetDomJob");
         q.AddJob<ColesPetDomJob>(opts => opts.WithIdentity(jobKeyColesPet));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesPet)
             .WithIdentity("ColesPetDomJob-trigger")
-            .WithCronSchedule("0 0 1 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 7 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesHomeGarden = new JobKey("ColesHomeGardenDomJob");
         q.AddJob<ColesHomeGardenDomJob>(opts => opts.WithIdentity(jobKeyColesHomeGarden));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesHomeGarden)
             .WithIdentity("ColesHomeGardenDomJob-trigger")
-            .WithCronSchedule("0 30 1 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 8 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesBigPackValue = new JobKey("ColesBigPackValueDomJob");
         q.AddJob<ColesBigPackValueDomJob>(opts => opts.WithIdentity(jobKeyColesBigPackValue));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesBigPackValue)
             .WithIdentity("ColesBigPackValueDomJob-trigger")
-            .WithCronSchedule("0 0 2 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 8 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesBonusCreditProducts = new JobKey("ColesBonusCreditProductsDomJob");
         q.AddJob<ColesBonusCreditProductsDomJob>(opts => opts.WithIdentity(jobKeyColesBonusCreditProducts));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesBonusCreditProducts)
             .WithIdentity("ColesBonusCreditProductsDomJob-trigger")
-            .WithCronSchedule("0 30 2 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 10 9 ? * WED", x => x.InTimeZone(localTz)));
 
         var jobKeyColesDeliverMoreRange = new JobKey("ColesDeliverMoreRangeDomJob");
         q.AddJob<ColesDeliverMoreRangeDomJob>(opts => opts.WithIdentity(jobKeyColesDeliverMoreRange));
         q.AddTrigger(opts => opts
             .ForJob(jobKeyColesDeliverMoreRange)
             .WithIdentity("ColesDeliverMoreRangeDomJob-trigger")
-            .WithCronSchedule("0 0 3 ? * TUE", x => x.InTimeZone(localTz)));
+            .WithCronSchedule("0 40 9 ? * WED", x => x.InTimeZone(localTz)));
 
         // delete data (quarterly, first Tuesday 06:00)
         var cleanJobKey = new JobKey("CleanPriceHistoryJob");
@@ -343,7 +347,7 @@ if (enableQuartzJobs)
             .WithIdentity("FavoritePriceTrackingJob-trigger")
         // testing
         // .WithCronSchedule("0 */1 * ? * *"));
-        .WithCronSchedule("0 10 6 ? * TUE", x => x.InTimeZone(localTz)));
+        .WithCronSchedule("0 50 12 ? * WED", x => x.InTimeZone(localTz)));
     });
 
     builder.Services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
@@ -386,6 +390,7 @@ builder.Services.AddScoped<IWoolworthsEverydayLowPriceDomScraperService, Woolwor
 builder.Services.AddScoped<IWoolworthsHalfPriceDomScraperService, WoolworthsHalfPriceDomScraperService>();
 builder.Services.AddScoped<IWoolworthsBuyMoreSaveMoreDomScraperService, WoolworthsBuyMoreSaveMoreDomScraperService>();
 builder.Services.AddScoped<IWoolworthsSummerPriceDomScraperService, WoolworthsSummerPriceDomScraperService>();
+builder.Services.AddScoped<IWoolworthsAutumnPriceDomScraperService, WoolworthsAutumnPriceDomScraperService>();
 
 builder.Services.AddScoped<ICategoryMappingService, CategoryMappingService>();
 

--- a/template.yaml
+++ b/template.yaml
@@ -325,7 +325,7 @@ Resources:
     Type: AWS::Scheduler::Schedule
     Properties:
       Name: !Sub "price-compare-${Environment}-favorite-price-tracking"
-      ScheduleExpression: "cron(10 6 ? * TUE *)"
+      ScheduleExpression: "cron(50 12 ? * WED *)"
       ScheduleExpressionTimezone: "Australia/Sydney"
       FlexibleTimeWindow:
         Mode: "OFF"


### PR DESCRIPTION
- Add IWoolworthsAutumnPriceDomScraperService + WoolworthsAutumnPriceDomScraperService
    targeting /shop/browse/specials/autumn-price (OfferType=26, PromoText="autumn price")
- Add WwsAutumnPriceDomJob with ColesDomJobLock semaphore
- Add GET /api/Scraping/woolworths/autumn-price/dom endpoint
- Add OfferType.AUTUMN_PRICE = 26 and CacheKey.WOOLWORTHS_AUTUMN_PRICE_PRODUCTS
- Move Wed 12:40 cron trigger from WwsSummerPriceDomJob to WwsAutumnPriceDomJob
- Mark WwsSummerPriceDomJob as .StoreDurably() so Quartz accepts it without a trigger
    (summer-price API endpoint kept for backward compatibility)