### PR TITLE
BTS-117: Filter `GET /api/Products` to only return products that were seen in the most recent scraping run, on a per-shop basis

### DIFF
--- a/src/PriceCompareCore/Services/ProductService.cs
+++ b/src/PriceCompareCore/Services/ProductService.cs
@@ -29,7 +29,22 @@ namespace PriceCompareCore.Services
 
             try
             {
-                var query = _db.Products.AsNoTracking().AsQueryable();
+                // Derived table: one MAX per shop type — executed once, not per row.
+                // Avoids the correlated subquery that caused the 30-second timeout.
+                var latestPerShop = _db.Products
+                    .AsNoTracking()
+                    .Where(p => p.ShopType.HasValue)
+                    .GroupBy(p => p.ShopType)
+                    .Select(g => new { ShopType = g.Key, MaxDate = g.Max(p => p.LastSeenAt.Date) });
+
+                var query = _db.Products
+                    .AsNoTracking()
+                    .Join(
+                        latestPerShop,
+                        p => new { p.ShopType, Date = p.LastSeenAt.Date },
+                        l => new { l.ShopType, Date = l.MaxDate },
+                        (p, l) => p
+                    );
 
                 if (!string.IsNullOrWhiteSpace(name))
                 {

--- a/src/PriceCompareData/Data/AppDbContext.cs
+++ b/src/PriceCompareData/Data/AppDbContext.cs
@@ -51,6 +51,10 @@ namespace PriceCompareData.Data
                   modelBuilder.Entity<Product>().HasIndex(p => new { p.ShopType, p.NormalizedName });
                   modelBuilder.Entity<Product>()
                       .HasIndex(p => new { p.CategoryId, p.SizeStandardUnit, p.SizeStandardValue });
+                  // Index to support per-shop latest-scrape-date filter in ProductService
+                  modelBuilder.Entity<Product>()
+                      .HasIndex(p => new { p.ShopType, p.LastSeenAt })
+                      .HasDatabaseName("IX_Products_ShopType_LastSeenAt");
 
                   // ProductMatch
                   modelBuilder.Entity<ProductMatch>(entity =>


### PR DESCRIPTION
- For each `ShopType`, compute the maximum `DATE(LastSeenAt)` across all products belonging to that shop.
- Only return products whose `DATE(LastSeenAt)` equals the per-shop maximum.
- The filter must apply per `ShopType` independently, so a scraper failure on one shop does not suppress products from another shop.
- The filter must use `DATE` granularity (calendar day), not the raw timestamp, so that products ingested at different times within the same scrape day (e.g. 00:10 vs 12:40 on Wednesday) are all treated as equally current.
- All existing query parameters (`name`, `shopType`, `categoryId`, `page`, `pageSize`, `includePrice`) must continue to work correctly after the filter is applied.

Related Jira Key: BTS-117