### PR TITLE
BTS-118 BTS-119: Sort product cards on the Products page so that cards with a confirmed `same_product` match appear before cards without one; add instruction to the tour

### DIFF
--- a/client/web/src/ProductsPage.tsx
+++ b/client/web/src/ProductsPage.tsx
@@ -554,6 +554,7 @@ export default function ProductsPage() {
 											<Typography
 												variant="caption"
 												fontWeight={600}
+												className="recommendation-text"
 												sx={{ textAlign: "center" }}
 											>
 												{recommendationText}

--- a/client/web/src/hooks/useTour.ts
+++ b/client/web/src/hooks/useTour.ts
@@ -38,6 +38,14 @@ function createTourDriver() {
 				},
 			},
 			{
+				element: ".recommendation-text",
+				popover: {
+					title: "Purchase Recommendation",
+					description:
+						"When a matching product is found at another store, we show which shop is cheaper and how much you can save.",
+				},
+			},
+			{
 				element: ".favorite-btn",
 				popover: {
 					title: "Save Favourites",

--- a/src/PriceCompareCore/Services/ProductService.cs
+++ b/src/PriceCompareCore/Services/ProductService.cs
@@ -64,10 +64,24 @@ namespace PriceCompareCore.Services
                 _logger.LogInformation("GetProducts count done total={Total}", total);
 
                 var hasFilter = !string.IsNullOrWhiteSpace(name) || shopType.HasValue || categoryId.HasValue;
-                // Avoid full-table sort by name when listing all products; use PK order unless filtered.
+
+                // Materialize same_product source IDs once into a List<Guid>.
+                // EF Core / Npgsql translates List.Contains() to "= ANY(@ids)" — a single fast lookup
+                // per row using the product PK, avoiding a correlated subquery on every row.
+                var sameProductIds = await _db.ProductMatches
+                    .Where(m => m.MatchType == "same_product")
+                    .Select(m => m.SourceProductId)
+                    .Distinct()
+                    .ToListAsync();
+
                 var orderedQuery = hasFilter
-                    ? query.OrderBy(p => p.Name).ThenBy(p => p.ProductId)
-                    : query.OrderBy(p => p.ProductId);
+                    ? query
+                        .OrderByDescending(p => sameProductIds.Contains(p.ProductId) ? 1 : 0)
+                        .ThenBy(p => p.Name)
+                        .ThenBy(p => p.ProductId)
+                    : query
+                        .OrderByDescending(p => sameProductIds.Contains(p.ProductId) ? 1 : 0)
+                        .ThenBy(p => p.ProductId);
 
                 var itemsQuery = orderedQuery
                     .Skip((page - 1) * pageSize)

--- a/src/PriceCompareData/Data/AppDbContext.cs
+++ b/src/PriceCompareData/Data/AppDbContext.cs
@@ -62,6 +62,10 @@ namespace PriceCompareData.Data
                         entity.ToTable("productmatch");
                         entity.HasKey(e => e.Id);
 
+                        // Index for same_product sort: SELECT sourceproductid WHERE matchtype = 'same_product'
+                        entity.HasIndex(e => new { e.MatchType, e.SourceProductId })
+                              .HasDatabaseName("IX_ProductMatch_MatchType_SourceProductId");
+
                         entity.Property(e => e.Id).HasColumnName("id");
                         entity.Property(e => e.SourceProductId).HasColumnName("sourceproductid");
                         entity.Property(e => e.TargetProductId).HasColumnName("targetproductid");


### PR DESCRIPTION
BTS-118 BTS-119