### PR TITLE
BTS-137: Rebrand UI to Price Peer + navbar redesign + product grid density

### DIFF
--- a/client/web/logo/price-peer-icon.svg
+++ b/client/web/logo/price-peer-icon.svg
@@ -1,0 +1,15 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(16, 22)">
+<!-- Tag 1 — solid blue -->
+<g transform="rotate(-15, 44, 40)">
+<rect x="0" y="0" width="72" height="54" rx="7" fill="#3b82f6"/>
+<circle cx="12" cy="12" r="5.5" fill="white" opacity="0.5"/>
+</g>
+<!-- Tag 2 — transparent purple -->
+<g transform="rotate(10, 64, 40)">
+<rect x="32" y="4" width="72" height="54" rx="7" fill="#8b5cf6" opacity="0.4"/>
+<rect x="32" y="4" width="72" height="54" rx="7" fill="none" stroke="#8b5cf6" stroke-width="2.5"/>
+<circle cx="44" cy="16" r="5.5" fill="white" opacity="0.4"/>
+</g>
+</g>
+</svg>

--- a/client/web/logo/price-peer-logo-compact.svg
+++ b/client/web/logo/price-peer-logo-compact.svg
@@ -1,0 +1,23 @@
+<svg width="320" height="48" viewBox="0 0 320 48" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<linearGradient id="brandGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+<stop offset="0%" stop-color="#3b82f6"/>
+<stop offset="100%" stop-color="#8b5cf6"/>
+</linearGradient>
+</defs>
+<g transform="translate(6, 6)">
+<!-- Small tag 1 — solid blue -->
+<g transform="rotate(-12, 18, 18)">
+<rect x="0" y="0" width="40" height="30" rx="4" fill="#3b82f6"/>
+<circle cx="7" cy="7" r="2.8" fill="white" opacity="0.5"/>
+</g>
+<!-- Small tag 2 — transparent purple -->
+<g transform="rotate(8, 36, 18)">
+<rect x="18" y="2" width="40" height="30" rx="4" fill="#8b5cf6" opacity="0.4"/>
+<rect x="18" y="2" width="40" height="30" rx="4" fill="none" stroke="#8b5cf6" stroke-width="1.5"/>
+<circle cx="25" cy="9" r="2.8" fill="white" opacity="0.4"/>
+</g>
+<!-- Single-line wordmark -->
+<text x="72" y="26" font-family="system-ui, -apple-system, sans-serif" font-size="24" font-weight="700" fill="url(#brandGrad)">Price-peer</text>
+</g>
+</svg>

--- a/client/web/logo/price-peer-logo-horizontal.svg
+++ b/client/web/logo/price-peer-logo-horizontal.svg
@@ -1,0 +1,24 @@
+<svg width="400" height="80" viewBox="0 0 400 80" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<linearGradient id="brandGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+<stop offset="0%" stop-color="#3b82f6"/>
+<stop offset="100%" stop-color="#8b5cf6"/>
+</linearGradient>
+</defs>
+<g transform="translate(10, 8)">
+<!-- Tag 1 — solid blue -->
+<g transform="rotate(-15, 32, 32)">
+<rect x="0" y="0" width="56" height="42" rx="5" fill="#3b82f6"/>
+<circle cx="9" cy="9" r="4" fill="white" opacity="0.5"/>
+</g>
+<!-- Tag 2 — transparent purple -->
+<g transform="rotate(10, 52, 32)">
+<rect x="26" y="2" width="56" height="42" rx="5" fill="#8b5cf6" opacity="0.45"/>
+<rect x="26" y="2" width="56" height="42" rx="5" fill="none" stroke="#8b5cf6" stroke-width="2"/>
+<circle cx="35" cy="11" r="4" fill="white" opacity="0.4"/>
+</g>
+<!-- Wordmark -->
+<text x="102" y="26" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="700" fill="url(#brandGrad)">Price</text>
+<text x="102" y="52" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="300" fill="#8b5cf6" opacity="0.7">peer</text>
+</g>
+</svg>

--- a/client/web/public/index.html
+++ b/client/web/public/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/price-peer-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Price Compare web application" />
+    <meta name="theme-color" content="#3b82f6" />
+    <meta name="description" content="Price Peer — compare supermarket prices" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Price-peer</title>
+    <title>Price Peer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/web/public/manifest.json
+++ b/client/web/public/manifest.json
@@ -1,7 +1,12 @@
 {
-  "short_name": "Price-peer",
-  "name": "Price-peer",
+  "short_name": "Price Peer",
+  "name": "Price Peer",
   "icons": [
+    {
+      "src": "price-peer-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    },
     {
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",

--- a/client/web/public/price-peer-icon.svg
+++ b/client/web/public/price-peer-icon.svg
@@ -1,0 +1,15 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(16, 22)">
+<!-- Tag 1 — solid blue -->
+<g transform="rotate(-15, 44, 40)">
+<rect x="0" y="0" width="72" height="54" rx="7" fill="#3b82f6"/>
+<circle cx="12" cy="12" r="5.5" fill="white" opacity="0.5"/>
+</g>
+<!-- Tag 2 — transparent purple -->
+<g transform="rotate(10, 64, 40)">
+<rect x="32" y="4" width="72" height="54" rx="7" fill="#8b5cf6" opacity="0.4"/>
+<rect x="32" y="4" width="72" height="54" rx="7" fill="none" stroke="#8b5cf6" stroke-width="2.5"/>
+<circle cx="44" cy="16" r="5.5" fill="white" opacity="0.4"/>
+</g>
+</g>
+</svg>

--- a/client/web/public/price-peer-logo-horizontal.svg
+++ b/client/web/public/price-peer-logo-horizontal.svg
@@ -1,0 +1,24 @@
+<svg width="400" height="80" viewBox="0 0 400 80" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<linearGradient id="brandGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+<stop offset="0%" stop-color="#3b82f6"/>
+<stop offset="100%" stop-color="#8b5cf6"/>
+</linearGradient>
+</defs>
+<g transform="translate(10, 8)">
+<!-- Tag 1 — solid blue -->
+<g transform="rotate(-15, 32, 32)">
+<rect x="0" y="0" width="56" height="42" rx="5" fill="#3b82f6"/>
+<circle cx="9" cy="9" r="4" fill="white" opacity="0.5"/>
+</g>
+<!-- Tag 2 — transparent purple -->
+<g transform="rotate(10, 52, 32)">
+<rect x="26" y="2" width="56" height="42" rx="5" fill="#8b5cf6" opacity="0.45"/>
+<rect x="26" y="2" width="56" height="42" rx="5" fill="none" stroke="#8b5cf6" stroke-width="2"/>
+<circle cx="35" cy="11" r="4" fill="white" opacity="0.4"/>
+</g>
+<!-- Wordmark -->
+<text x="102" y="26" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="700" fill="url(#brandGrad)">Price</text>
+<text x="102" y="52" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="300" fill="#8b5cf6" opacity="0.7">peer</text>
+</g>
+</svg>

--- a/client/web/src/App.tsx
+++ b/client/web/src/App.tsx
@@ -212,8 +212,10 @@ function App() {
 				position="sticky"
 				elevation={0}
 				sx={{
-					background:
-						"linear-gradient(90deg, #0ea5e9 0%, #6366f1 50%, #a855f7 100%)",
+					background: "linear-gradient(90deg, rgba(59,130,246,0.12) 0%, rgba(139,92,246,0.12) 100%)",
+					backdropFilter: "blur(12px)",
+					WebkitBackdropFilter: "blur(12px)",
+					borderBottom: "1px solid rgba(99, 102, 241, 0.15)",
 				}}
 			>
 				<Toolbar sx={{ py: { xs: 1, sm: 1.5 } }}>
@@ -225,27 +227,29 @@ function App() {
 							flexDirection: { xs: "column", md: "row" },
 						}}
 					>
-						<Typography
-							variant="h4"
+						<Box
 							component="h1"
 							sx={{
 								flexGrow: { xs: 0, md: 1 },
-								fontWeight: 800,
-								letterSpacing: 0.5,
-								textShadow: "0 1px 2px rgba(0,0,0,.25)",
-								fontSize: { xs: 22, sm: 26, md: 30, lg: 34 },
+								m: 0,
 								textAlign: { xs: "center", sm: "left" },
 								width: { xs: "100%", md: "auto" },
+								display: "flex",
+								justifyContent: { xs: "center", sm: "flex-start" },
 							}}
 						>
-							Price-peer
-						</Typography>
+							<Box
+								component="img"
+								src="/price-peer-logo-horizontal.svg"
+								alt="Price Peer"
+								sx={{ height: { xs: 48, sm: 58, md: 68 }, width: "auto" }}
+							/>
+						</Box>
 						{showTabs && (
 							<Tabs
 								value={mainTab}
 								onChange={handleTabChange}
-								textColor="inherit"
-								indicatorColor="secondary"
+								textColor="primary"
 								sx={{
 									ml: { xs: 0, md: 2 },
 									mt: { xs: 1, md: 0 },
@@ -255,6 +259,13 @@ function App() {
 									"& .MuiTab-root": {
 										minHeight: "auto",
 										fontSize: { xs: 12, sm: 13, md: 14 },
+										color: "text.secondary",
+									},
+									"& .MuiTab-root.Mui-selected": {
+										color: "#6366f1",
+									},
+									"& .MuiTabs-indicator": {
+										backgroundColor: "#6366f1",
 									},
 								}}
 							>
@@ -273,11 +284,11 @@ function App() {
 									ml: { xs: 0, md: 2 },
 									mt: { xs: 1, md: 0 },
 									fontWeight: 500,
+									color: "text.secondary",
 									maxWidth: { xs: 140, sm: 200 },
 									overflow: "hidden",
 									textOverflow: "ellipsis",
 									whiteSpace: "nowrap",
-									textShadow: "0 1px 1px rgba(0,0,0,0.25)",
 								}}
 							>
 								{userEmail}
@@ -290,7 +301,7 @@ function App() {
 									ml: { xs: 0, md: 2 },
 									mt: { xs: 1, md: 0 },
 									fontWeight: 500,
-									textShadow: "0 1px 1px rgba(0,0,0,0.25)",
+									color: "text.secondary",
 								}}
 							>
 								Guest access
@@ -298,12 +309,12 @@ function App() {
 						)}
 						{isAuthenticated && (
 							<Button
-								color="inherit"
 								onClick={handleLogout}
 								sx={{
 									fontWeight: 500,
 									ml: { xs: 0, md: 2 },
 									mt: { xs: 1, md: 0 },
+									color: "text.secondary",
 								}}
 							>
 								Log out
@@ -311,12 +322,15 @@ function App() {
 						)}
 						{(isGuest || (!isAuthenticated && !auth.isLoading)) && (
 							<Button
-								color="inherit"
+								variant="contained"
 								onClick={() => auth.signinRedirect()}
 								sx={{
 									fontWeight: 500,
 									ml: { xs: 0, md: 2 },
 									mt: { xs: 1, md: 0 },
+									background: "linear-gradient(90deg, #3b82f6, #8b5cf6)",
+									boxShadow: "none",
+									"&:hover": { background: "linear-gradient(90deg, #2563eb, #7c3aed)", boxShadow: "none" },
 								}}
 							>
 								Sign in

--- a/client/web/src/ProductsPage.tsx
+++ b/client/web/src/ProductsPage.tsx
@@ -415,6 +415,7 @@ export default function ProductsPage() {
 			>
 				<span>
 					<IconButton
+						id="ai-search-btn"
 						onClick={() => setAiSearchOpen(true)}
 						disabled={aiSearchExhausted}
 						color={aiSearchOpen ? "primary" : "default"}
@@ -467,12 +468,12 @@ export default function ProductsPage() {
 						sx={{
 							display: "grid",
 							gridTemplateColumns: {
-								xs: "1fr",
-								sm: "repeat(2, minmax(0, 1fr))",
-								md: "repeat(3, minmax(0, 1fr))",
-								lg: "repeat(4, minmax(0, 1fr))",
+								xs: "repeat(2, minmax(0, 1fr))",
+								sm: "repeat(3, minmax(0, 1fr))",
+								md: "repeat(4, minmax(0, 1fr))",
+								lg: "repeat(5, minmax(0, 1fr))",
 							},
-							gap: { xs: 2, sm: 2.5, md: 3 },
+							gap: { xs: 1, sm: 1.5, md: 2 },
 						}}
 					>
 						{rows.map((row) => {

--- a/client/web/src/hooks/useTour.ts
+++ b/client/web/src/hooks/useTour.ts
@@ -16,6 +16,14 @@ function createTourDriver() {
 				},
 			},
 			{
+				element: "#ai-search-btn",
+				popover: {
+					title: "AI Search",
+					description:
+						"Can't find what you're looking for? Click here to describe it in any language — our AI will figure out the product for you. e.g. '澳大利亚最有名的饼干' or 'something sweet to put on toast'.",
+				},
+			},
+			{
 				element: "#shop-filter",
 				popover: {
 					title: "Filter by Shop",


### PR DESCRIPTION
Summary                                                                                                                                                                                  

  Apply the Price Peer brand identity across the app: update the browser tab, navbar, and PWA manifest to use the new logo and name. Redesign the navbar with a frosted-glass style.       
  Increase product grid density. Add an AI Search step to the onboarding tour.


Changes

  Branding
  - Browser tab title changed from Price-peer to Price Peer
  - Favicon replaced with price-peer-icon.svg (SVG, resolution-independent)
  - theme-color meta updated to brand blue #3b82f6 (affects Android Chrome address bar)
  - PWA manifest.json name/short_name updated; SVG icon added to icons list

  Navbar
  - Replaced plain text wordmark with price-peer-logo-horizontal.svg (icon + two-line "Price / peer" wordmark), responsive height (48–68px)
  - Background changed from solid gradient to frosted glass: rgba blue-purple tint at 12% opacity + backdrop-filter: blur(12px) + subtle purple bottom border
  - Tab selected colour and indicator updated to #6366f1 (brand indigo)
  - Sign In button upgraded to gradient-filled contained button matching brand colours
  - Log Out / email / Guest text changed to text.secondary for legibility on light background

  Product Grid
  - Columns increased by one at every breakpoint (xs: 1→2, sm: 2→3, md: 3→4, lg: 4→5)
  - Gap reduced from 2–3 to 1–2 to fit more cards without increasing scroll depth

  Onboarding Tour
  - Added AI Search step (targets #ai-search-btn) between the search input step and the shop filter step; explains multi-language support with examples

Related Jira Key: BTS-137