### PR TITLE
BTS-140: Added Batch SQL Generation for Scrape Exports

### DIFF
--- a/src/PriceCompareData/Common/WebInfo.cs
+++ b/src/PriceCompareData/Common/WebInfo.cs
@@ -9,7 +9,7 @@ namespace PriceCompareData.Entities.Common
     {
         public const string COLES_BASE_URL = "https://www.coles.com.au";
         // Next.js build id used in Coles _next/data URLs. Update this when Coles deploys.
-        public const string COLES_NEXT_BUILD_ID = "20260326.1-e04350c8cd5bfce66ee7c1f052f5f5eaa36c0754";
+        public const string COLES_NEXT_BUILD_ID = "20260413.1-7b71ff44d92d413d7d1b712b532a2fb8ed643433";
         public const string COLES_NEXT_DATA_BASE = COLES_BASE_URL + "/_next/data/" + COLES_NEXT_BUILD_ID;
     }
 }

--- a/src/PriceCompareWeb/Controllers/AdminController.cs
+++ b/src/PriceCompareWeb/Controllers/AdminController.cs
@@ -85,6 +85,14 @@ public class AdminController : ControllerBase
         return Ok(result);
     }
 
+    [HttpPost("scrape-import/generate-all-sql")]
+    public async Task<IActionResult> GenerateAllScrapeSql(
+        [FromQuery] bool skipExisting = true, CancellationToken ct = default)
+    {
+        var result = await _scrapeImportSqlService.GenerateAllAsync(skipExisting, ct);
+        return Ok(result);
+    }
+
     [HttpGet("schedules/{jobName}/runs")]
     public async Task<IActionResult> GetRuns(
         string jobName,

--- a/src/PriceCompareWeb/Controllers/Models/ScrapeImportDtos.cs
+++ b/src/PriceCompareWeb/Controllers/Models/ScrapeImportDtos.cs
@@ -12,4 +12,19 @@ namespace PriceCompareWeb.Controllers.Models
         int PriceHistoryRows,
         int ProductRows,
         string? SqlPreview);
+
+    public record ScrapeImportAllFolderResult(
+        string ExportDir,
+        string? OutputPath,
+        int PriceHistoryRows,
+        int ProductRows,
+        bool Skipped,
+        string? Error);
+
+    public record ScrapeImportAllResult(
+        int Total,
+        int Generated,
+        int Skipped,
+        int Failed,
+        IReadOnlyList<ScrapeImportAllFolderResult> Folders);
 }

--- a/src/PriceCompareWeb/Services/ScrapeImportSqlService.cs
+++ b/src/PriceCompareWeb/Services/ScrapeImportSqlService.cs
@@ -17,6 +17,7 @@ namespace PriceCompareWeb.Services
     public interface IScrapeImportSqlService
     {
         Task<ScrapeImportSqlResult> GenerateAsync(ScrapeImportSqlRequest request, CancellationToken ct = default);
+        Task<ScrapeImportAllResult> GenerateAllAsync(bool skipExisting, CancellationToken ct = default);
     }
 
     public class ScrapeImportSqlService : IScrapeImportSqlService
@@ -110,6 +111,53 @@ namespace PriceCompareWeb.Services
                 priceHistoryRows,
                 productRows,
                 preview);
+        }
+
+        public async Task<ScrapeImportAllResult> GenerateAllAsync(bool skipExisting, CancellationToken ct = default)
+        {
+            var root = ResolveRoot();
+            if (!Directory.Exists(root))
+            {
+                throw new InvalidOperationException($"Export root not found: {root}");
+            }
+
+            var dirs = Directory.GetDirectories(root).OrderBy(d => d).ToList();
+            var folders = new List<ScrapeImportAllFolderResult>(dirs.Count);
+            var skipped = 0;
+            var failed = 0;
+            var generated = 0;
+
+            foreach (var dir in dirs)
+            {
+                ct.ThrowIfCancellationRequested();
+                var folderName = Path.GetFileName(dir);
+                var sqlPath = Path.Combine(dir, "import.sql");
+
+                if (skipExisting && File.Exists(sqlPath))
+                {
+                    skipped++;
+                    folders.Add(new ScrapeImportAllFolderResult(folderName, sqlPath, 0, 0, Skipped: true, Error: null));
+                    continue;
+                }
+
+                try
+                {
+                    var result = await GenerateAsync(new ScrapeImportSqlRequest(folderName, null, false, null), ct);
+                    generated++;
+                    folders.Add(new ScrapeImportAllFolderResult(
+                        result.ExportDir, result.OutputPath,
+                        result.PriceHistoryRows, result.ProductRows,
+                        Skipped: false, Error: null));
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    _logger.LogError(ex, "Failed to generate SQL for {Folder}", folderName);
+                    folders.Add(new ScrapeImportAllFolderResult(folderName, null, 0, 0, Skipped: false, Error: ex.Message));
+                }
+            }
+
+            return new ScrapeImportAllResult(dirs.Count, generated, skipped, failed, folders);
         }
 
         private string ResolveRoot()

--- a/template.yaml
+++ b/template.yaml
@@ -357,7 +357,7 @@ Resources:
     Type: AWS::Scheduler::Schedule
     Properties:
       Name: !Sub "price-compare-${Environment}-favorite-price-tracking"
-      ScheduleExpression: "cron(50 12 ? * WED *)"
+      ScheduleExpression: "cron(50 13 ? * WED *)"
       ScheduleExpressionTimezone: "Australia/Sydney"
       FlexibleTimeWindow:
         Mode: "OFF"


### PR DESCRIPTION
Goal: Iterate all subfolders under the exports root and generate import.sql for each in a single API call, replacing the previous one-folder-at-a-time manual process

Related Jira Key: BTS-140