### PR TITLE
BTS-147: Restyle frontend with glassmorphism (liquid glass) theme

### DIFF
--- a/client/web/src/App.tsx
+++ b/client/web/src/App.tsx
@@ -207,15 +207,16 @@ function App() {
 	};
 
 	return (
-		<Box sx={{ bgcolor: "background.default", minHeight: "100vh" }}>
+		<Box sx={{ bgcolor: "transparent", minHeight: "100vh" }}>
 			<AppBar
 				position="sticky"
 				elevation={0}
 				sx={{
-					background: "linear-gradient(90deg, rgba(59,130,246,0.12) 0%, rgba(139,92,246,0.12) 100%)",
-					backdropFilter: "blur(12px)",
-					WebkitBackdropFilter: "blur(12px)",
-					borderBottom: "1px solid rgba(99, 102, 241, 0.15)",
+					background: "rgba(255,255,255,0.55)",
+					backdropFilter: "blur(30px) saturate(180%)",
+					WebkitBackdropFilter: "blur(30px) saturate(180%)",
+					borderBottom: "0.5px solid rgba(255,255,255,0.6)",
+					boxShadow: "0 1px 0 rgba(0,0,0,0.04)",
 				}}
 			>
 				<Toolbar sx={{ py: { xs: 1, sm: 1.5 } }}>
@@ -250,22 +251,30 @@ function App() {
 								value={mainTab}
 								onChange={handleTabChange}
 								textColor="primary"
+								variant="scrollable"
+								scrollButtons={false}
+								allowScrollButtonsMobile
 								sx={{
 									ml: { xs: 0, md: 2 },
 									mt: { xs: 1, md: 0 },
 									minHeight: "auto",
+									maxWidth: "100%",
 									width: { xs: "100%", md: "auto" },
-									justifyContent: { xs: "center", md: "flex-start" },
+									"& .MuiTabs-flexContainer": {
+										justifyContent: { xs: "center", md: "flex-start" },
+									},
 									"& .MuiTab-root": {
 										minHeight: "auto",
+										minWidth: "auto",
+										px: { xs: 1.25, md: 2 },
 										fontSize: { xs: 12, sm: 13, md: 14 },
 										color: "text.secondary",
 									},
 									"& .MuiTab-root.Mui-selected": {
-										color: "#6366f1",
+										color: "#6e7bff",
 									},
 									"& .MuiTabs-indicator": {
-										backgroundColor: "#6366f1",
+										backgroundColor: "#6e7bff",
 									},
 								}}
 							>
@@ -277,65 +286,63 @@ function App() {
 								)}
 							</Tabs>
 						)}
-						{isAuthenticated && userEmail && (
-							<Typography
-								variant="body2"
-								sx={{
-									ml: { xs: 0, md: 2 },
-									mt: { xs: 1, md: 0 },
-									fontWeight: 500,
-									color: "text.secondary",
-									maxWidth: { xs: 140, sm: 200 },
-									overflow: "hidden",
-									textOverflow: "ellipsis",
-									whiteSpace: "nowrap",
-								}}
-							>
-								{userEmail}
-							</Typography>
-						)}
-						{isGuest && (
-							<Typography
-								variant="body2"
-								sx={{
-									ml: { xs: 0, md: 2 },
-									mt: { xs: 1, md: 0 },
-									fontWeight: 500,
-									color: "text.secondary",
-								}}
-							>
-								Guest access
-							</Typography>
-						)}
-						{isAuthenticated && (
-							<Button
-								onClick={handleLogout}
-								sx={{
-									fontWeight: 500,
-									ml: { xs: 0, md: 2 },
-									mt: { xs: 1, md: 0 },
-									color: "text.secondary",
-								}}
-							>
-								Log out
-							</Button>
-						)}
-						{(isGuest || (!isAuthenticated && !auth.isLoading)) && (
-							<Button
-								variant="contained"
-								onClick={() => auth.signinRedirect()}
-								sx={{
-									fontWeight: 500,
-									ml: { xs: 0, md: 2 },
-									mt: { xs: 1, md: 0 },
-									background: "linear-gradient(90deg, #3b82f6, #8b5cf6)",
-									boxShadow: "none",
-									"&:hover": { background: "linear-gradient(90deg, #2563eb, #7c3aed)", boxShadow: "none" },
-								}}
-							>
-								Sign in
-							</Button>
-						)}
+						<Box
+							sx={{
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								flexWrap: "wrap",
+								gap: 1,
+								width: { xs: "100%", md: "auto" },
+								mt: { xs: 1, md: 0 },
+								ml: { md: 2 },
+							}}
+						>
+							{isAuthenticated && userEmail && (
+								<Typography
+									variant="body2"
+									sx={{
+										fontWeight: 500,
+										color: "text.secondary",
+										maxWidth: { xs: 180, sm: 200 },
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+										whiteSpace: "nowrap",
+									}}
+								>
+									{userEmail}
+								</Typography>
+							)}
+							{isGuest && (
+								<Typography
+									variant="body2"
+									sx={{ fontWeight: 500, color: "text.secondary" }}
+								>
+									Guest access
+								</Typography>
+							)}
+							{isAuthenticated && (
+								<Button
+									onClick={handleLogout}
+									sx={{ fontWeight: 500, color: "text.secondary" }}
+								>
+									Log out
+								</Button>
+							)}
+							{(isGuest || (!isAuthenticated && !auth.isLoading)) && (
+								<Button
+									variant="contained"
+									onClick={() => auth.signinRedirect()}
+									sx={{
+										fontWeight: 500,
+										background: "linear-gradient(135deg, #6e7bff, #8b6eff)",
+										"&:hover": { background: "linear-gradient(135deg, #6e7bff, #8b6eff)", filter: "brightness(1.06)" },
+									}}
+								>
+									Sign in
+								</Button>
+							)}
+						</Box>
 					</Container>
 				</Toolbar>
 			</AppBar>

--- a/client/web/src/ProductsPage.tsx
+++ b/client/web/src/ProductsPage.tsx
@@ -72,8 +72,8 @@ function ProductImage({
 			<Box
 				sx={{
 					height: { xs: 130, sm: 170 },
-					borderRadius: 2.5,
-					bgcolor: "#f5f5f7",
+					borderRadius: 4,
+					bgcolor: "rgba(255,255,255,0.55)",
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "center",
@@ -102,8 +102,8 @@ function ProductImage({
 				height: 170,
 				width: "100%",
 				objectFit: "contain",
-				borderRadius: 2.5,
-				backgroundColor: "#ffffff",
+				borderRadius: 4,
+				backgroundColor: "rgba(255,255,255,0.7)",
 			}}
 		/>
 	);
@@ -356,13 +356,32 @@ export default function ProductsPage() {
 
 	return (
 		<Box sx={{ width: "100%" }}>
-			<Stack direction={{ xs: "column", sm: "row" }} spacing={2} sx={{ mb: 2 }}>
+			<Stack
+				direction={{ xs: "column", sm: "row" }}
+				spacing={2}
+				alignItems="center"
+				justifyContent="center"
+				sx={{
+					mb: 3,
+					p: 1.5,
+					borderRadius: 5,
+					width: { xs: "100%", sm: "fit-content" },
+					maxWidth: "100%",
+					mx: "auto",
+					background: "rgba(255,255,255,0.55)",
+					backdropFilter: "blur(24px) saturate(180%)",
+					WebkitBackdropFilter: "blur(24px) saturate(180%)",
+					border: "0.5px solid rgba(255,255,255,0.7)",
+					boxShadow: "0 8px 30px rgba(60,60,90,0.08)",
+				}}
+			>
 				<TextField
 					id="search-input"
 					label="Search by name"
 					variant="outlined"
 					size="small"
 					fullWidth={isXs}
+					sx={{ width: { xs: "100%", sm: 240 } }}
 					value={search}
 					onChange={(e) => {
 						setSearch(e.target.value);
@@ -399,9 +418,19 @@ export default function ProductsPage() {
 						))}
 					</Select>
 				</FormControl>
+				<Box
+					sx={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						flexWrap: "wrap",
+						gap: 1.5,
+						width: { xs: "100%", sm: "auto" },
+					}}
+				>
 				<Button
 					variant="contained"
-					sx={{ width: { xs: "100%", sm: "auto" } }}
+					sx={{ flexGrow: { xs: 1, sm: 0 } }}
 					onClick={() => setRefreshTick((v) => v + 1)}
 				>
 					Search
@@ -426,14 +455,18 @@ export default function ProductsPage() {
 				</span>
 			</Tooltip>
 			<TourButton onClick={startTour} disabled={compareOpen} />
+				</Box>
 			</Stack>
 
 			<Box
 				sx={{
 					position: "relative",
-					borderRadius: 4,
-					border: "1px solid #edf1f5",
-					bgcolor: "#fafafa",
+					borderRadius: 5,
+					border: "0.5px solid rgba(255,255,255,0.6)",
+					background: "rgba(255,255,255,0.35)",
+					backdropFilter: "blur(20px) saturate(180%)",
+					WebkitBackdropFilter: "blur(20px) saturate(180%)",
+					boxShadow: "0 8px 30px rgba(60,60,90,0.06)",
 					p: { xs: 1.5, sm: 2.5 },
 					overflow: "hidden",
 				}}
@@ -502,10 +535,17 @@ export default function ProductsPage() {
 									sx={{
 										display: "flex",
 										flexDirection: "column",
-										borderRadius: 3.5,
-										border: "1px solid #e8edf2",
-										bgcolor: "#ffffff",
-										boxShadow: "0 18px 40px rgba(15, 23, 42, 0.08)",
+										borderRadius: 6,
+										border: "0.5px solid rgba(255,255,255,0.85)",
+										background: "rgba(255,255,255,0.6)",
+										backdropFilter: "blur(24px) saturate(180%)",
+										WebkitBackdropFilter: "blur(24px) saturate(180%)",
+										boxShadow: "0 10px 34px rgba(50,55,95,0.1)",
+										transition: "transform .25s ease, box-shadow .25s ease",
+										"&:hover": {
+											transform: "translateY(-5px)",
+											boxShadow: "0 20px 48px rgba(50,55,95,0.18)",
+										},
 									}}
 								>
 									<Box
@@ -514,7 +554,7 @@ export default function ProductsPage() {
 											pt: 2.5,
 											pb: 2,
 											background:
-												"linear-gradient(180deg, #f5f5f7 0%, #ffffff 100%)",
+												"linear-gradient(180deg, rgba(255,255,255,0.75) 0%, rgba(255,255,255,0.4) 100%)",
 										}}
 									>
 										<ProductImage src={row.imageUrl} alt={row.name} />

--- a/client/web/src/components/TourButton.tsx
+++ b/client/web/src/components/TourButton.tsx
@@ -13,7 +13,7 @@ export default function TourButton({ onClick, disabled }: TourButtonProps) {
 			size="small"
 			onClick={onClick}
 			disabled={disabled}
-			sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
+			sx={{ width: "auto", whiteSpace: "nowrap" }}
 		>
 			Tour / Help
 		</Button>

--- a/client/web/src/index.css
+++ b/client/web/src/index.css
@@ -1,13 +1,65 @@
 body {
 	margin: 0;
 	font-family:
-		-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-		"Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+		-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text",
+		"Segoe UI", "Roboto", "Helvetica Neue", sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	background: #eef0f4;
 }
 
 code {
 	font-family:
 		source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
+/* ===== Ambient colour-mesh background (liquid glass) ===== */
+@keyframes meshDrift {
+	0% {
+		transform: translate(0, 0) scale(1);
+	}
+	50% {
+		transform: translate(-3%, 2%) scale(1.05);
+	}
+	100% {
+		transform: translate(0, 0) scale(1);
+	}
+}
+
+body::before {
+	content: "";
+	position: fixed;
+	inset: -20%;
+	z-index: 0;
+	pointer-events: none;
+	animation: meshDrift 28s ease-in-out infinite;
+	background:
+		radial-gradient(40% 40% at 18% 22%, rgba(120, 135, 255, 0.55), transparent 70%),
+		radial-gradient(38% 38% at 82% 18%, rgba(255, 140, 180, 0.45), transparent 70%),
+		radial-gradient(45% 45% at 75% 80%, rgba(120, 205, 255, 0.5), transparent 70%),
+		radial-gradient(40% 40% at 25% 85%, rgba(180, 160, 255, 0.45), transparent 70%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	body::before {
+		animation: none;
+	}
+}
+
+/* App content must sit above the ambient mesh */
+#root {
+	position: relative;
+	z-index: 1;
+}
+
+/* ===== Custom scrollbar ===== */
+*::-webkit-scrollbar {
+	width: 10px;
+}
+*::-webkit-scrollbar-thumb {
+	background: rgba(120, 120, 128, 0.3);
+	border-radius: 8px;
+}
+*::-webkit-scrollbar-track {
+	background: transparent;
 }

--- a/client/web/src/index.tsx
+++ b/client/web/src/index.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { AuthProvider } from "react-oidc-context";
+import { ThemeProvider } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
 import "./index.css";
 import "driver.js/dist/driver.css";
 import App from "./App";
+import theme from "./theme";
 import { oidcConfig } from "./auth/oidcConfig";
 import reportWebVitals from "./reportWebVitals";
 
@@ -26,7 +29,10 @@ root.render(
 					);
 				}}
 			>
-				<App />
+				<ThemeProvider theme={theme}>
+					<CssBaseline />
+					<App />
+				</ThemeProvider>
 			</AuthProvider>
 		</BrowserRouter>
 	</React.StrictMode>,

--- a/client/web/src/theme.ts
+++ b/client/web/src/theme.ts
@@ -1,0 +1,125 @@
+import { createTheme } from "@mui/material/styles";
+
+/**
+ * Glassmorphism ("liquid glass") theme inspired by docs/frontend-style.
+ * Purple accent (#6e7bff → #8b6eff), translucent frosted surfaces,
+ * rounded corners and soft ambient shadows. The animated colour-mesh
+ * background lives in index.css (body::before); this theme styles the
+ * glass surfaces that sit on top of it.
+ */
+
+const ACCENT = "#6e7bff";
+const ACCENT_DARK = "#8b6eff";
+const TEXT_PRIMARY = "#1d1d1f";
+const TEXT_SECONDARY = "#86868b";
+
+const SF_STACK = [
+	"-apple-system",
+	"BlinkMacSystemFont",
+	'"SF Pro Display"',
+	'"SF Pro Text"',
+	'"Segoe UI"',
+	'"Helvetica Neue"',
+	"Roboto",
+	"sans-serif",
+].join(",");
+
+const theme = createTheme({
+	palette: {
+		mode: "light",
+		primary: { main: ACCENT, dark: ACCENT_DARK, contrastText: "#ffffff" },
+		secondary: { main: ACCENT_DARK, contrastText: "#ffffff" },
+		success: { main: "#1f9d57" },
+		warning: { main: "#e08a1e" },
+		error: { main: "#ff3b6b" },
+		background: { default: "#eef0f4", paper: "rgba(255,255,255,0.62)" },
+		text: { primary: TEXT_PRIMARY, secondary: TEXT_SECONDARY },
+		divider: "rgba(120,120,128,0.2)",
+	},
+	shape: { borderRadius: 14 },
+	typography: {
+		fontFamily: SF_STACK,
+		h4: { fontWeight: 700, letterSpacing: "-0.03em" },
+		h5: { fontWeight: 700, letterSpacing: "-0.02em" },
+		h6: { fontWeight: 700, letterSpacing: "-0.02em" },
+		subtitle1: { letterSpacing: "-0.01em" },
+		button: { textTransform: "none", fontWeight: 600, letterSpacing: "-0.01em" },
+	},
+	components: {
+		MuiButton: {
+			defaultProps: { disableElevation: true },
+			styleOverrides: {
+				root: { borderRadius: 13, paddingInline: 18 },
+				containedPrimary: {
+					background: `linear-gradient(135deg, ${ACCENT}, ${ACCENT_DARK})`,
+					boxShadow: "0 6px 16px rgba(110,123,255,0.35)",
+					"&:hover": {
+						background: `linear-gradient(135deg, ${ACCENT}, ${ACCENT_DARK})`,
+						filter: "brightness(1.06)",
+						boxShadow: "0 8px 20px rgba(110,123,255,0.42)",
+					},
+				},
+				outlinedPrimary: {
+					borderColor: "rgba(110,123,255,0.4)",
+					backgroundColor: "rgba(110,123,255,0.06)",
+					"&:hover": {
+						borderColor: ACCENT,
+						backgroundColor: "rgba(110,123,255,0.14)",
+					},
+				},
+			},
+		},
+		MuiCard: {
+			styleOverrides: {
+				root: {
+					borderRadius: 22,
+					backgroundColor: "rgba(255,255,255,0.6)",
+					backdropFilter: "blur(24px) saturate(180%)",
+					WebkitBackdropFilter: "blur(24px) saturate(180%)",
+					border: "0.5px solid rgba(255,255,255,0.85)",
+					boxShadow: "0 10px 34px rgba(50,55,95,0.1)",
+					backgroundImage: "none",
+				},
+			},
+		},
+		MuiPaper: {
+			styleOverrides: {
+				root: { backgroundImage: "none" },
+			},
+		},
+		MuiDialog: {
+			styleOverrides: {
+				paper: {
+					borderRadius: 24,
+					backgroundColor: "rgba(255,255,255,0.78)",
+					backdropFilter: "blur(30px) saturate(180%)",
+					WebkitBackdropFilter: "blur(30px) saturate(180%)",
+					border: "0.5px solid rgba(255,255,255,0.7)",
+					boxShadow: "0 24px 70px rgba(50,55,95,0.22)",
+				},
+			},
+		},
+		MuiChip: {
+			styleOverrides: {
+				root: { borderRadius: 980, fontWeight: 600 },
+			},
+		},
+		MuiOutlinedInput: {
+			styleOverrides: {
+				root: {
+					borderRadius: 13,
+					backgroundColor: "rgba(120,120,128,0.08)",
+					"& fieldset": { borderColor: "rgba(120,120,128,0.18)" },
+					"&:hover fieldset": { borderColor: "rgba(110,123,255,0.4)" },
+				},
+			},
+		},
+		MuiTab: {
+			styleOverrides: {
+				root: { textTransform: "none", fontWeight: 500, letterSpacing: "-0.01em" },
+			},
+		},
+	},
+});
+
+export default theme;


### PR DESCRIPTION
BTS-147

Apply an Apple-style frosted-glass look across the app, keeping the existing logo unchanged.

  - Add centralized MUI theme (client/web/src/theme.ts): purple accent
    (#6e7bff -> #8b6eff), translucent frosted Card/Dialog/Paper, pill
    buttons with gradient + glow, rounded inputs, SF Pro type stack.
  - Wrap App in ThemeProvider + CssBaseline in index.tsx.
  - Add animated colour-mesh background in index.css (body::before with
    radial gradients + meshDrift, disabled under prefers-reduced-motion)
    and custom scrollbars.
  - Make the app root transparent and convert the top nav bar to frosted
    glass in App.tsx; unify tab/sign-in accents to purple.
  - Glass-ify the ProductsPage search toolbar, grid container and product
    cards (hover lift); center the search toolbar and shrink its frame to
    fit its contents.