### PR TITLE
BTS-150: Harden admin authorization and add zero-cost /api/admin/whoami

### DIFF
--- a/client/web/src/App.tsx
+++ b/client/web/src/App.tsx
@@ -29,7 +29,7 @@ import LoginPage from "./LoginPage";
 import CallbackPage from "./CallbackPage";
 import { clearGuestSession, getStoredGuest, setGuestSession } from "./api/auth";
 import { buildCognitoLogoutUrl } from "./auth/oidcConfig";
-import { fetchAdminHealth } from "./api/admin";
+import { fetchAdminWhoAmI } from "./api/admin";
 import MyReceiptsPage from "./MyReceiptsPage";
 import MyFavoritesPage from "./MyFavoritesPage";
 import AdminJobsPage from "./AdminJobsPage";
@@ -72,7 +72,7 @@ function App() {
 		}
 		(async () => {
 			try {
-				await fetchAdminHealth(1);
+				await fetchAdminWhoAmI();
 				if (active) setIsAdmin(true);
 			} catch {
 				if (active) setIsAdmin(false);

--- a/client/web/src/api/admin.ts
+++ b/client/web/src/api/admin.ts
@@ -56,6 +56,18 @@ export type AdminHealth = {
 	recentFailures: AdminFailure[];
 };
 
+export type AdminWhoAmI = {
+	isAdmin: boolean;
+	email?: string | null;
+};
+
+// Lightweight probe of the AdminOnly policy: resolves for admins, rejects (403)
+// for everyone else. Does no DB work server-side, unlike fetchAdminHealth.
+export async function fetchAdminWhoAmI(): Promise<AdminWhoAmI> {
+	const res = await axios.get(`${API_BASE}/api/admin/whoami`);
+	return res.data;
+}
+
 export async function fetchAdminSchedules(source?: string): Promise<JobSchedule[]> {
 	const params = source ? { source } : undefined;
 	const res = await axios.get(`${API_BASE}/api/admin/schedules`, { params });

--- a/src/PriceCompareWeb/Controllers/AdminController.cs
+++ b/src/PriceCompareWeb/Controllers/AdminController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -24,6 +25,16 @@ public class AdminController : ControllerBase
         _db = db;
         _scheduleService = scheduleService;
         _scrapeImportSqlService = scrapeImportSqlService;
+    }
+
+    /// <summary>
+    /// Cheapest possible probe of the AdminOnly policy: the frontend calls this on every
+    /// login just to learn whether it is allowed through, so it must not touch the DB.
+    /// </summary>
+    [HttpGet("whoami")]
+    public IActionResult WhoAmI()
+    {
+        return Ok(new AdminWhoAmIDto(true, User.FindFirstValue(ClaimTypes.Email)));
     }
 
     [HttpGet("schedules")]

--- a/src/PriceCompareWeb/Controllers/Models/AdminDtos.cs
+++ b/src/PriceCompareWeb/Controllers/Models/AdminDtos.cs
@@ -16,6 +16,10 @@ namespace PriceCompareWeb.Controllers.Models
         int? LastRunDurationMs,
         string? LastRunErrorMessage);
 
+    public record AdminWhoAmIDto(
+        bool IsAdmin,
+        string? Email);
+
     public record AdminFailureDto(
         string JobName,
         string Source,

--- a/src/PriceCompareWeb/Program.cs
+++ b/src/PriceCompareWeb/Program.cs
@@ -473,6 +473,13 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("AdminOnly", policy =>
         policy.RequireAssertion(ctx =>
         {
+            // An unverified email proves nothing about who owns it, so an allow-listed
+            // address alone must not grant admin. Cognito emits email_verified as a JSON
+            // boolean; the JWT handler stringifies it with no contractual casing.
+            var emailVerified = ctx.User.FindFirstValue("email_verified");
+            if (!string.Equals(emailVerified, "true", StringComparison.OrdinalIgnoreCase))
+                return false;
+
             var email = ctx.User.FindFirstValue(ClaimTypes.Email);
             return !string.IsNullOrWhiteSpace(email) &&
                    adminEmails.Any(a => string.Equals(a, email, StringComparison.OrdinalIgnoreCase));

--- a/template.yaml
+++ b/template.yaml
@@ -274,6 +274,12 @@ Resources:
             ApiId: !Ref AppHttpApi
             Path: /api/Favorites/{productId}
             Method: PUT
+        AdminWhoAmIGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref AppHttpApi
+            Path: /api/admin/whoami
+            Method: GET
         AdminSchedulesGet:
           Type: HttpApi
           Properties:


### PR DESCRIPTION
The AdminOnly policy matched the JWT email claim against the allow-list without checking whether that email was ever verified. If the Cognito user pool permits self-service sign-up, an unverified account registered with an admin's address would satisfy the policy. Require email_verified == true before the allow-list comparison, compared case-insensitively since the JWT handler's stringification of the JSON boolean is not contractual.

Separately, App.tsx resolved isAdmin by calling GET /api/admin/health?rangeHours=1 purely to observe whether it 403s, discarding the result. That ran three JobRuns aggregate queries against Postgres on every login for every authenticated user. Add GET /api/admin/whoami, covered by the existing class-level AdminOnly attribute, which touches no database and returns { isAdmin, email }, and point the frontend check at it. fetchAdminHealth stays: the Admin Monitoring page still uses it.

The frontend /admin route guard and tab visibility are unchanged. They are UX only - the admin path and every endpoint string are visible in the JS bundle, and the security boundary is and remains the server-side policy.

Deploy note: /api/admin/whoami is a new API Gateway route, so backend and frontend must ship together. Until the route exists the frontend gets a 404 and every user resolves to isAdmin=false, hiding the Admin tab.