### PR TITLE
Update Coles Next.js build ID and gitignore AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ tools/KeywordMiner/appsettings.json
 .claude/
 docs/
 CLAUDE.md
+AGENTS.md

--- a/src/PriceCompareData/Common/WebInfo.cs
+++ b/src/PriceCompareData/Common/WebInfo.cs
@@ -9,7 +9,7 @@ namespace PriceCompareData.Entities.Common
     {
         public const string COLES_BASE_URL = "https://www.coles.com.au";
         // Next.js build id used in Coles _next/data URLs. Update this when Coles deploys.
-        public const string COLES_NEXT_BUILD_ID = "20260710.1-8c479c3aa89f9da04be29ccef400771ec3af9cd1";
+        public const string COLES_NEXT_BUILD_ID = "20260814.4-42e5f7ce808d415777482c42c76722f26b06a428";
         public const string COLES_NEXT_DATA_BASE = COLES_BASE_URL + "/_next/data/" + COLES_NEXT_BUILD_ID;
     }
 }


### PR DESCRIPTION
- Bump COLES_NEXT_BUILD_ID to 20260814.4 to match Coles' latest deploy
- Add AGENTS.md to .gitignore