### PR TITLE
BTS-166: Scope the scrape upsert lookup to the current batch

### DIFF
--- a/src/PriceCompareCore/Services/IngestionService.cs
+++ b/src/PriceCompareCore/Services/IngestionService.cs
@@ -139,9 +139,31 @@ namespace PriceCompareCore.Services
 
             var shopTypes = list.Select(c => c.ShopType).Distinct().ToList();
 
-            // Load all existing products for the batch's shop type(s) in one query
+            // Load only the existing products this batch could possibly match, keyed the same way
+            // the lookups below are (SourceId first, Name as fallback).
+            //
+            // This previously loaded EVERY product for the shop type on every scraper run. With ~26
+            // weekly scrapers each pulling the whole shop catalogue into memory (and into the EF
+            // change tracker), that was the single largest source of Supabase read pressure and of
+            // scraper runtime. A batch is typically a few hundred to a couple of thousand rows, so
+            // scoping the query is an order-of-magnitude reduction. Npgsql translates these
+            // Contains() calls to `= ANY(@p)` (one array parameter each), not a giant IN list.
+            var batchSourceIds = list
+                .Where(c => !string.IsNullOrWhiteSpace(c.SourceId))
+                .Select(c => c.SourceId!)
+                .Distinct()
+                .ToList();
+
+            var batchNames = list
+                .Where(c => !string.IsNullOrWhiteSpace(c.Name))
+                .Select(c => c.Name!)
+                .Distinct()
+                .ToList();
+
             var existingProducts = await _dbContext.Products
-                .Where(p => shopTypes.Contains(p.ShopType))
+                .Where(p => shopTypes.Contains(p.ShopType)
+                            && ((p.SourceId != null && batchSourceIds.Contains(p.SourceId))
+                                || (p.Name != null && batchNames.Contains(p.Name))))
                 .ToListAsync();
 
             // Build O(1) lookups: SourceId-first, Name-fallback


### PR DESCRIPTION
IngestionService.UpsertAsync loaded every product for the shop type on each run (WHERE shoptype = X, no further filter), pulling the whole catalogue into memory and into the EF change tracker. With ~26 scrape jobs per week that full scan ran 26 times over, making it the largest single source of Supabase read pressure and a significant part of scraper runtime.

Load only the rows the batch can actually match, keyed the same way the lookups below already are: sourceid = ANY(@ids) OR name = ANY(@names). Npgsql renders each Contains() as a single array parameter rather than a large IN list, so the parameter count stays constant regardless of batch size. A batch is typically a few hundred to a couple of thousand rows against a catalogue of tens of thousands.

No behaviour change: the SourceId-first / Name-fallback matching, the update and insert branches, and the same-batch duplicate handling are all untouched.

Verified: dotnet build across the solution reports 0 errors. dotnet test gives 14 passed / 4 failed / 1 skipped; the same 4 failures (ScrapeImportSqlService x2, ReceiptOcrParser x2) reproduce on the unmodified baseline, so they are pre-existing and unrelated.